### PR TITLE
feat(userprog): 사용자 프로그램에 인자 전달 기능 구현

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+SortIncludes: true

--- a/pintos/generate_test_config.py
+++ b/pintos/generate_test_config.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+# 사용법 : 
+# make check > make-check-output.txt
+# python3 generate_test_config.py < make-check-output.txt > .test_config
+
+import re
+import os
+import sys
+from collections import defaultdict
+from datetime import date
+
+# 제거할 공통 플래그
+COMMON_FLAGS = {"-v", "-k"}
+COMMON_OPTS_WITH_VAL = {"-T", "-m"}
+
+def clean_pre_args(arg_str):
+    """
+    - '-v', '-k' 플래그 제거
+    - '-T <num>', '-m <num>' 쌍 제거
+    """
+    tokens = arg_str.split()
+    out = []
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t in COMMON_FLAGS:
+            i += 1
+        elif t in COMMON_OPTS_WITH_VAL and i + 1 < len(tokens):
+            i += 2
+        else:
+            out.append(t)
+            i += 1
+    return " ".join(out)
+
+def parse_line(line):
+    # 일반 테스트 (non-thread) 파싱
+    if ' <' in line:
+        line = line.split(' <', 1)[0]
+    line = line.strip()
+    if not line.startswith('pintos'):
+        return None
+    rest = line[len('pintos'):].strip()
+    if ' -- ' not in rest:
+        return None
+    pre, post = rest.split(' -- ', 1)
+    pre = pre.strip()
+    post = post.strip()
+    m = re.search(r'(-f run)(?:\s+(.*))?$', post)
+    if not m:
+        return None
+    runner = post[:m.end(1)].strip()
+    prog = (post[m.end(1):].strip() or '').strip()
+    m2 = re.search(r'-p\s+([^:\s]+):([^\s]+)', pre)
+    if not m2:
+        return None
+    full_path, test_name = m2.group(1), m2.group(2)
+    test_path = os.path.dirname(full_path)
+    clean_pre = clean_pre_args(pre)
+    return test_path, test_name, clean_pre, runner, prog
+
+def main():
+    lines = [L.rstrip("\n") for L in sys.stdin]
+    groups = defaultdict(list)
+
+    # 1) non-thread 테스트 우선 파싱
+    for line in lines:
+        parsed = parse_line(line)
+        if parsed:
+            test_path, name, pre, runner, prog = parsed
+            if not test_path.startswith('tests/threads'):
+                groups[test_path].append((name, pre, runner, prog))
+
+    # 2) summary 섹션에서 thread 테스트 목록 추출
+    summary = []
+    in_summary = False
+    for line in reversed(lines):
+        if not in_summary:
+            if re.match(r'^\d+ of \d+ tests', line):
+                in_summary = True
+            continue
+        if not line.strip():
+            continue
+        m = re.match(r'^(?:pass|FAIL)\s+(tests/threads/([^/\s]+))', line)
+        if m:
+            full_path = m.group(1)
+            test_name = m.group(2)
+            summary.append((full_path, test_name))
+        else:
+            break
+    summary.reverse()
+
+    # 3) 각 thread 테스트에 대해 pintos 실행 라인 찾아 파싱
+    for full_path, name in summary:
+        cmd_line = next((L for L in lines
+                         if L.startswith('pintos')
+                         and '-threads-tests' in L
+                         and f' {name}' in L), None)
+        if not cmd_line:
+            continue
+        if ' <' in cmd_line:
+            cmd_line = cmd_line.split(' <', 1)[0]
+        rest = cmd_line[len('pintos'):].strip()
+        pre, post = rest.split(' -- ', 1)
+        pre = pre.strip()
+        post = post.strip()
+        m = re.search(r'(-f run)(?:\s+(.*))?$', post)
+        if not m:
+            continue
+        runner = post[:m.end(1)].strip()
+        prog = (post[m.end(1):].strip() or '').strip()
+        test_path = os.path.dirname(full_path)
+        clean_pre = clean_pre_args(pre)
+        groups[test_path].append((name, clean_pre, runner, prog))
+
+    # Header: 파일 포맷 설명
+    print("# .test_config format:")
+    print("# test_name | pre_args | post_args | prog_args | test_path")
+    print("#")
+    print("# Fields:")
+    print("#   test_name : 테스트 식별용 이름")
+    print("#   pre_args  : 'pintos' 호출 시 -- 이전 옵션들")
+    print("#   post_args : 'pintos' 호출 시 -- 이후, run 이전 옵션들")
+    print("#   prog_args : 작은따옴표로 묶인 테스트 실행 인자 전체")
+    print("#   test_path : 테스트 바이너리 경로 (호스트 파일 시스템 내)")
+    print()
+
+    total = sum(len(entries) for entries in groups.values())
+    for test_path, entries in groups.items():
+        group = test_path
+        if group.startswith('tests/'):
+            group = group[len('tests/'):]
+        print(f'[{group}]')
+        for name, pre, runner, prog in entries:
+            if prog.startswith("'") and prog.endswith("'"):
+                prog_field = prog
+            elif prog:
+                prog_field = f"'{prog}'"
+            else:
+                prog_field = "''"
+            print(f"{name} | {pre} | {runner} | {prog_field} | {test_path}")
+        print()
+
+    # Footer: 총 개수 및 생성 날짜
+    print(f"# Total testcases: {total}")
+    print(f"# Generated on {date.today().isoformat()}")
+
+if __name__ == '__main__':
+    main()

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -12,10 +12,10 @@
 
 /* States in a thread's life cycle. */
 enum thread_status {
-	THREAD_RUNNING,     /* Running thread. */
-	THREAD_READY,       /* Not running but ready to run. */
-	THREAD_BLOCKED,     /* Waiting for an event to trigger. */
-	THREAD_DYING        /* About to be destroyed. */
+  THREAD_RUNNING, /* Running thread. */
+  THREAD_READY, /* Not running but ready to run. */
+  THREAD_BLOCKED, /* Waiting for an event to trigger. */
+  THREAD_DYING /* About to be destroyed. */
 };
 
 /* Thread identifier type.
@@ -87,40 +87,41 @@ typedef int tid_t;
  * blocked state is on a semaphore wait list. */
 // 👇👇👇 TCB(Thread Control Block)
 struct thread {
-	/* Owned by thread.c. */
-	tid_t tid;                          /* Thread identifier. */
-	enum thread_status status;          /* Thread state. */
-	char name[16];                      /* Name (for debugging purposes). */
-	int priority;                       /* Priority. */
-	int64_t wakeup_tick;			/* 깨워야 할 tick */
+  /* Owned by thread.c. */
+  tid_t tid; /* Thread identifier. */
+  enum thread_status status; /* Thread state. */
+  char name[16]; /* Name (for debugging purposes). */
+  int priority; /* Priority. */
+  int64_t wakeup_tick; /* 깨워야 할 tick */
 
-	int base_priority; // 기존 우선순위
-	struct lock* waiting_lock; // 대기중인 lock
-	struct list_elem donation_elem; // 내가 다른 스레드의 donation_list에 들어갈 때 쓰이는 원소
-	struct list donation_list; // 나에게 donation해준 스레드들의 리스트
+  int base_priority; // 기존 우선순위
+  struct lock* waiting_lock; // 대기중인 lock
+  struct list_elem donation_elem; // 내가 다른 스레드의 donation_list에 들어갈 때 쓰이는 원소
+  struct list donation_list; // 나에게 donation해준 스레드들의 리스트
 
-	int nice; // nice 값
-	int64_t recent_cpu; // recent_cpu 값
-	struct list_elem all_elem; // all_list에 들어갈 때 쓰이는 원소
+  int nice; // nice 값
+  int64_t recent_cpu; // recent_cpu 값
+  struct list_elem all_elem; // all_list에 들어갈 때 쓰이는 원소
 
-	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;              /* List element. */
+  /* Shared between thread.c and synch.c. */
+  struct list_elem elem; /* List element. */
 
 #ifdef USERPROG
-	/* Owned by userprog/process.c. */
-	uint64_t *pml4;                     /* Page map level 4 */
+  /* Owned by userprog/process.c. */
+  uint64_t* pml4; /* Page map level 4 */
 #endif
 #ifdef VM
-	/* Table for whole virtual memory owned by thread. */
-	struct supplemental_page_table spt;
+  /* Table for whole virtual memory owned by thread. */
+  struct supplemental_page_table spt;
 #endif
 
-	/* Owned by thread.c. */
-	// 👇👇👇 컨텍스트 스위칭을 위한 레지스터 저장소 : 스레드가 중단될 때 모든 CPU 레지스터 값을 저장
-	struct intr_frame tf;               /* Information for switching */
-	// 👆👆👆 컨텍스트 스위칭을 위한 레지스터 저장소 : 스레드가 중단될 때 모든 CPU 레지스터 값을 저장
-	unsigned magic;                     /* Detects stack overflow. */
+  /* Owned by thread.c. */
+  // 👇👇👇 컨텍스트 스위칭을 위한 레지스터 저장소 : 스레드가 중단될 때 모든 CPU 레지스터 값을 저장
+  struct intr_frame tf; /* Information for switching */
+  // 👆👆👆 컨텍스트 스위칭을 위한 레지스터 저장소 : 스레드가 중단될 때 모든 CPU 레지스터 값을 저장
+  unsigned magic; /* Detects stack overflow. */
 };
+
 // 👆👆👆 TCB(Thread Control Block)
 
 extern struct list sleep_list; // sleep 상태인 스레드들을 담는 리스트
@@ -130,33 +131,33 @@ extern struct list sleep_list; // sleep 상태인 스레드들을 담는 리스�
    Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
 
-void thread_init (void);
-void thread_start (void);
+void thread_init(void);
+void thread_start(void);
 
-void thread_tick (void);
-void thread_print_stats (void);
+void thread_tick(void);
+void thread_print_stats(void);
 
-typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+typedef void thread_func(void* aux);
+tid_t thread_create(const char* name, int priority, thread_func*, void*);
 
-void thread_block (void);
-void thread_unblock (struct thread *);
+void thread_block(void);
+void thread_unblock(struct thread*);
 
-struct thread *thread_current (void);
-tid_t thread_tid (void);
-const char *thread_name (void);
+struct thread* thread_current(void);
+tid_t thread_tid(void);
+const char* thread_name(void);
 
-void thread_exit (void) NO_RETURN;
-void thread_yield (void);
+void thread_exit(void) NO_RETURN;
+void thread_yield(void);
 
-int thread_get_priority (void);
-void thread_set_priority (int);
+int thread_get_priority(void);
+void thread_set_priority(int);
 
-int thread_get_nice (void);
-void thread_set_nice (int);
-int thread_get_recent_cpu (void);
-int thread_get_load_avg (void);
+int thread_get_nice(void);
+void thread_set_nice(int);
+int thread_get_recent_cpu(void);
+int thread_get_load_avg(void);
 
-void do_iret (struct intr_frame *tf);
+void do_iret(struct intr_frame* tf);
 
 #endif /* threads/thread.h */

--- a/pintos/launch.json
+++ b/pintos/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "[Week 9]Threads Debug",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/pintos/threads/build/kernel.o",
+      "cwd": "${workspaceFolder}/pintos/threads",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "miDebuggerServerAddress": "localhost:1234",
+    },
+    {
+      "name": "[Week 10-11]User Program Debug",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/pintos/userprog/build/kernel.o",
+      "cwd": "${workspaceFolder}/pintos/userprog",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "miDebuggerServerAddress": "localhost:1234",
+    },
+    {
+      "name": "[Week 12-13]VM Debug",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/pintos/vm/build/kernel.o",
+      "cwd": "${workspaceFolder}/pintos/vm",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "miDebuggerServerAddress": "localhost:1234"
+    },
+  ]
+}

--- a/pintos/lib/string.c
+++ b/pintos/lib/string.c
@@ -3,41 +3,41 @@
 
 /* Copies SIZE bytes from SRC to DST, which must not overlap.
    Returns DST. */
-void *
-memcpy (void *dst_, const void *src_, size_t size) {
-	unsigned char *dst = dst_;
-	const unsigned char *src = src_;
+void*
+memcpy(void* dst_, const void* src_, size_t size) {
+  unsigned char* dst = dst_;
+  const unsigned char* src = src_;
 
-	ASSERT (dst != NULL || size == 0);
-	ASSERT (src != NULL || size == 0);
+  ASSERT(dst != NULL || size == 0);
+  ASSERT(src != NULL || size == 0);
 
-	while (size-- > 0)
-		*dst++ = *src++;
+  while (size-- > 0)
+    *dst++ = *src++;
 
-	return dst_;
+  return dst_;
 }
 
 /* Copies SIZE bytes from SRC to DST, which are allowed to
    overlap.  Returns DST. */
-void *
-memmove (void *dst_, const void *src_, size_t size) {
-	unsigned char *dst = dst_;
-	const unsigned char *src = src_;
+void*
+memmove(void* dst_, const void* src_, size_t size) {
+  unsigned char* dst = dst_;
+  const unsigned char* src = src_;
 
-	ASSERT (dst != NULL || size == 0);
-	ASSERT (src != NULL || size == 0);
+  ASSERT(dst != NULL || size == 0);
+  ASSERT(src != NULL || size == 0);
 
-	if (dst < src) {
-		while (size-- > 0)
-			*dst++ = *src++;
-	} else {
-		dst += size;
-		src += size;
-		while (size-- > 0)
-			*--dst = *--src;
-	}
+  if (dst < src) {
+    while (size-- > 0)
+      *dst++ = *src++;
+  } else {
+    dst += size;
+    src += size;
+    while (size-- > 0)
+      *--dst = *--src;
+  }
 
-	return dst;
+  return dst;
 }
 
 /* Find the first differing byte in the two blocks of SIZE bytes
@@ -45,17 +45,17 @@ memmove (void *dst_, const void *src_, size_t size) {
    greater, a negative value if the byte in B is greater, or zero
    if blocks A and B are equal. */
 int
-memcmp (const void *a_, const void *b_, size_t size) {
-	const unsigned char *a = a_;
-	const unsigned char *b = b_;
+memcmp(const void* a_, const void* b_, size_t size) {
+  const unsigned char* a = a_;
+  const unsigned char* b = b_;
 
-	ASSERT (a != NULL || size == 0);
-	ASSERT (b != NULL || size == 0);
+  ASSERT(a != NULL || size == 0);
+  ASSERT(b != NULL || size == 0);
 
-	for (; size-- > 0; a++, b++)
-		if (*a != *b)
-			return *a > *b ? +1 : -1;
-	return 0;
+  for (; size-- > 0; a++, b++)
+    if (*a != *b)
+      return *a > *b ? +1 : -1;
+  return 0;
 }
 
 /* Finds the first differing characters in strings A and B.
@@ -64,122 +64,122 @@ memcmp (const void *a_, const void *b_, size_t size) {
    an unsigned char) is greater, or zero if strings A and B are
    equal. */
 int
-strcmp (const char *a_, const char *b_) {
-	const unsigned char *a = (const unsigned char *) a_;
-	const unsigned char *b = (const unsigned char *) b_;
+strcmp(const char* a_, const char* b_) {
+  const unsigned char* a = (const unsigned char*)a_;
+  const unsigned char* b = (const unsigned char*)b_;
 
-	ASSERT (a != NULL);
-	ASSERT (b != NULL);
+  ASSERT(a != NULL);
+  ASSERT(b != NULL);
 
-	while (*a != '\0' && *a == *b) {
-		a++;
-		b++;
-	}
+  while (*a != '\0' && *a == *b) {
+    a++;
+    b++;
+  }
 
-	return *a < *b ? -1 : *a > *b;
+  return *a < *b ? -1 : *a > *b;
 }
 
 /* Returns a pointer to the first occurrence of CH in the first
    SIZE bytes starting at BLOCK.  Returns a null pointer if CH
    does not occur in BLOCK. */
-void *
-memchr (const void *block_, int ch_, size_t size) {
-	const unsigned char *block = block_;
-	unsigned char ch = ch_;
+void*
+memchr(const void* block_, int ch_, size_t size) {
+  const unsigned char* block = block_;
+  unsigned char ch = ch_;
 
-	ASSERT (block != NULL || size == 0);
+  ASSERT(block != NULL || size == 0);
 
-	for (; size-- > 0; block++)
-		if (*block == ch)
-			return (void *) block;
+  for (; size-- > 0; block++)
+    if (*block == ch)
+      return (void*)block;
 
-	return NULL;
+  return NULL;
 }
 
 /* Finds and returns the first occurrence of C in STRING, or a
    null pointer if C does not appear in STRING.  If C == '\0'
    then returns a pointer to the null terminator at the end of
    STRING. */
-char *
-strchr (const char *string, int c_) {
-	char c = c_;
+char*
+strchr(const char* string, int c_) {
+  char c = c_;
 
-	ASSERT (string);
+  ASSERT(string);
 
-	for (;;)
-		if (*string == c)
-			return (char *) string;
-		else if (*string == '\0')
-			return NULL;
-		else
-			string++;
+  for (;;)
+    if (*string == c)
+      return (char*)string;
+    else if (*string == '\0')
+      return NULL;
+    else
+      string++;
 }
 
 /* Returns the length of the initial substring of STRING that
    consists of characters that are not in STOP. */
 size_t
-strcspn (const char *string, const char *stop) {
-	size_t length;
+strcspn(const char* string, const char* stop) {
+  size_t length;
 
-	for (length = 0; string[length] != '\0'; length++)
-		if (strchr (stop, string[length]) != NULL)
-			break;
-	return length;
+  for (length = 0; string[length] != '\0'; length++)
+    if (strchr(stop, string[length]) != NULL)
+      break;
+  return length;
 }
 
 /* Returns a pointer to the first character in STRING that is
    also in STOP.  If no character in STRING is in STOP, returns a
    null pointer. */
-char *
-strpbrk (const char *string, const char *stop) {
-	for (; *string != '\0'; string++)
-		if (strchr (stop, *string) != NULL)
-			return (char *) string;
-	return NULL;
+char*
+strpbrk(const char* string, const char* stop) {
+  for (; *string != '\0'; string++)
+    if (strchr(stop, *string) != NULL)
+      return (char*)string;
+  return NULL;
 }
 
 /* Returns a pointer to the last occurrence of C in STRING.
    Returns a null pointer if C does not occur in STRING. */
-char *
-strrchr (const char *string, int c_) {
-	char c = c_;
-	const char *p = NULL;
+char*
+strrchr(const char* string, int c_) {
+  char c = c_;
+  const char* p = NULL;
 
-	for (; *string != '\0'; string++)
-		if (*string == c)
-			p = string;
-	return (char *) p;
+  for (; *string != '\0'; string++)
+    if (*string == c)
+      p = string;
+  return (char*)p;
 }
 
 /* Returns the length of the initial substring of STRING that
    consists of characters in SKIP. */
 size_t
-strspn (const char *string, const char *skip) {
-	size_t length;
+strspn(const char* string, const char* skip) {
+  size_t length;
 
-	for (length = 0; string[length] != '\0'; length++)
-		if (strchr (skip, string[length]) == NULL)
-			break;
-	return length;
+  for (length = 0; string[length] != '\0'; length++)
+    if (strchr(skip, string[length]) == NULL)
+      break;
+  return length;
 }
 
 /* Returns a pointer to the first occurrence of NEEDLE within
    HAYSTACK.  Returns a null pointer if NEEDLE does not exist
    within HAYSTACK. */
-char *
-strstr (const char *haystack, const char *needle) {
-	size_t haystack_len = strlen (haystack);
-	size_t needle_len = strlen (needle);
+char*
+strstr(const char* haystack, const char* needle) {
+  size_t haystack_len = strlen(haystack);
+  size_t needle_len = strlen(needle);
 
-	if (haystack_len >= needle_len) {
-		size_t i;
+  if (haystack_len >= needle_len) {
+    size_t i;
 
-		for (i = 0; i <= haystack_len - needle_len; i++)
-			if (!memcmp (haystack + i, needle, needle_len))
-				return (char *) haystack + i;
-	}
+    for (i = 0; i <= haystack_len - needle_len; i++)
+      if (!memcmp(haystack + i, needle, needle_len))
+        return (char*)haystack + i;
+  }
 
-	return NULL;
+  return NULL;
 }
 
 /* Breaks a string into tokens separated by DELIMITERS.  The
@@ -215,77 +215,77 @@ outputs:
 'to'
 'tokenize.'
 */
-char *strtok_r (char *s, const char *delimiters, char **save_ptr) {
-	char *token;
+char* strtok_r(char* s, const char* delimiters, char** save_ptr) {
+  char* token;
 
-	ASSERT (delimiters != NULL);
-	ASSERT (save_ptr != NULL);
+  ASSERT(delimiters != NULL);
+  ASSERT(save_ptr != NULL);
 
-	/* If S is nonnull, start from it.
-	   If S is null, start from saved position. */
-	if (s == NULL)
-		s = *save_ptr;
-	ASSERT (s != NULL);
+  /* If S is nonnull, start from it.
+     If S is null, start from saved position. */
+  if (s == NULL)
+    s = *save_ptr;
+  ASSERT(s != NULL);
 
-	/* Skip any DELIMITERS at our current position. */
-	while (strchr (delimiters, *s) != NULL) {
-		/* strchr() will always return nonnull if we're searching
-		   for a null byte, because every string contains a null
-		   byte (at the end). */
-		if (*s == '\0') {
-			*save_ptr = s;
-			return NULL;
-		}
+  /* Skip any DELIMITERS at our current position. */
+  while (strchr(delimiters, *s) != NULL) {
+    /* strchr() will always return nonnull if we're searching
+       for a null byte, because every string contains a null
+       byte (at the end). */
+    if (*s == '\0') {
+      *save_ptr = s;
+      return NULL;
+    }
 
-		s++;
-	}
+    s++;
+  }
 
-	/* Skip any non-DELIMITERS up to the end of the string. */
-	token = s;
-	while (strchr (delimiters, *s) == NULL)
-		s++;
-	if (*s != '\0') {
-		*s = '\0';
-		*save_ptr = s + 1;
-	} else
-		*save_ptr = s;
-	return token;
+  /* Skip any non-DELIMITERS up to the end of the string. */
+  token = s;
+  while (strchr(delimiters, *s) == NULL)
+    s++;
+  if (*s != '\0') {
+    *s = '\0';
+    *save_ptr = s + 1;
+  } else
+    *save_ptr = s;
+  return token;
 }
 
 /* Sets the SIZE bytes in DST to VALUE. */
-void *
-memset (void *dst_, int value, size_t size) {
-	unsigned char *dst = dst_;
+void*
+memset(void* dst_, int value, size_t size) {
+  unsigned char* dst = dst_;
 
-	ASSERT (dst != NULL || size == 0);
+  ASSERT(dst != NULL || size == 0);
 
-	while (size-- > 0)
-		*dst++ = value;
+  while (size-- > 0)
+    *dst++ = value;
 
-	return dst_;
+  return dst_;
 }
 
 /* Returns the length of STRING. */
 size_t
-strlen (const char *string) {
-	const char *p;
+strlen(const char* string) {
+  const char* p;
 
-	ASSERT (string);
+  ASSERT(string);
 
-	for (p = string; *p != '\0'; p++)
-		continue;
-	return p - string;
+  for (p = string; *p != '\0'; p++)
+    continue;
+  return p - string;
 }
 
 /* If STRING is less than MAXLEN characters in length, returns
    its actual length.  Otherwise, returns MAXLEN. */
 size_t
-strnlen (const char *string, size_t maxlen) {
-	size_t length;
+strnlen(const char* string, size_t maxlen) {
+  size_t length;
 
-	for (length = 0; string[length] != '\0' && length < maxlen; length++)
-		continue;
-	return length;
+  for (length = 0; string[length] != '\0' && length < maxlen; length++)
+    continue;
+  return length;
 }
 
 /* Copies string SRC to DST.  If SRC is longer than SIZE - 1
@@ -298,21 +298,21 @@ strnlen (const char *string, size_t maxlen) {
 http://www.courtesan.com/todd/papers/strlcpy.html for
 information on strlcpy(). */
 size_t
-strlcpy (char *dst, const char *src, size_t size) {
-	size_t src_len;
+strlcpy(char* dst, const char* src, size_t size) {
+  size_t src_len;
 
-	ASSERT (dst != NULL);
-	ASSERT (src != NULL);
+  ASSERT(dst != NULL);
+  ASSERT(src != NULL);
 
-	src_len = strlen (src);
-	if (size > 0) {
-		size_t dst_len = size - 1;
-		if (src_len < dst_len)
-			dst_len = src_len;
-		memcpy (dst, src, dst_len);
-		dst[dst_len] = '\0';
-	}
-	return src_len;
+  src_len = strlen(src);
+  if (size > 0) {
+    size_t dst_len = size - 1;
+    if (src_len < dst_len)
+      dst_len = src_len;
+    memcpy(dst, src, dst_len);
+    dst[dst_len] = '\0';
+  }
+  return src_len;
 }
 
 /* Concatenates string SRC to DST.  The concatenated string is
@@ -326,21 +326,20 @@ strlcpy (char *dst, const char *src, size_t size) {
 http://www.courtesan.com/todd/papers/strlcpy.html for
 information on strlcpy(). */
 size_t
-strlcat (char *dst, const char *src, size_t size) {
-	size_t src_len, dst_len;
+strlcat(char* dst, const char* src, size_t size) {
+  size_t src_len, dst_len;
 
-	ASSERT (dst != NULL);
-	ASSERT (src != NULL);
+  ASSERT(dst != NULL);
+  ASSERT(src != NULL);
 
-	src_len = strlen (src);
-	dst_len = strlen (dst);
-	if (size > 0 && dst_len < size) {
-		size_t copy_cnt = size - dst_len - 1;
-		if (src_len < copy_cnt)
-			copy_cnt = src_len;
-		memcpy (dst + dst_len, src, copy_cnt);
-		dst[dst_len + copy_cnt] = '\0';
-	}
-	return src_len + dst_len;
+  src_len = strlen(src);
+  dst_len = strlen(dst);
+  if (size > 0 && dst_len < size) {
+    size_t copy_cnt = size - dst_len - 1;
+    if (src_len < copy_cnt)
+      copy_cnt = src_len;
+    memcpy(dst + dst_len, src, copy_cnt);
+    dst[dst_len + copy_cnt] = '\0';
+  }
+  return src_len + dst_len;
 }
-

--- a/pintos/userprog/.test_config
+++ b/pintos/userprog/.test_config
@@ -1,0 +1,120 @@
+# .test_config format:
+# test_name | pre_args | post_args | prog_args | test_path
+#
+# Fields:
+#   test_name : 테스트 식별용 이름
+#   pre_args  : 'pintos' 호출 시 -- 이전 옵션들
+#   post_args : 'pintos' 호출 시 -- 이후, run 이전 옵션들
+#   prog_args : 작은따옴표로 묶인 테스트 실행 인자 전체
+#   test_path : 테스트 바이너리 경로 (호스트 파일 시스템 내)
+
+[userprog]
+args-none | --fs-disk=10 -p tests/userprog/args-none:args-none | -q   -f run | 'args-none' | tests/userprog
+args-single | --fs-disk=10 -p tests/userprog/args-single:args-single | -q   -f run | 'args-single onearg' | tests/userprog
+args-multiple | --fs-disk=10 -p tests/userprog/args-multiple:args-multiple | -q   -f run | 'args-multiple some arguments for you!' | tests/userprog
+args-many | --fs-disk=10 -p tests/userprog/args-many:args-many | -q   -f run | 'args-many a b c d e f g h i j k l m n o p q r s t u v' | tests/userprog
+args-dbl-space | --fs-disk=10 -p tests/userprog/args-dbl-space:args-dbl-space | -q   -f run | 'args-dbl-space two  spaces!' | tests/userprog
+halt | --fs-disk=10 -p tests/userprog/halt:halt | -q   -f run | 'halt' | tests/userprog
+exit | --fs-disk=10 -p tests/userprog/exit:exit | -q   -f run | 'exit' | tests/userprog
+create-normal | --fs-disk=10 -p tests/userprog/create-normal:create-normal | -q   -f run | 'create-normal' | tests/userprog
+create-empty | --fs-disk=10 -p tests/userprog/create-empty:create-empty | -q   -f run | 'create-empty' | tests/userprog
+create-null | --fs-disk=10 -p tests/userprog/create-null:create-null | -q   -f run | 'create-null' | tests/userprog
+create-bad-ptr | --fs-disk=10 -p tests/userprog/create-bad-ptr:create-bad-ptr | -q   -f run | 'create-bad-ptr' | tests/userprog
+create-long | --fs-disk=10 -p tests/userprog/create-long:create-long | -q   -f run | 'create-long' | tests/userprog
+create-exists | --fs-disk=10 -p tests/userprog/create-exists:create-exists | -q   -f run | 'create-exists' | tests/userprog
+create-bound | --fs-disk=10 -p tests/userprog/create-bound:create-bound | -q   -f run | 'create-bound' | tests/userprog
+open-normal | --fs-disk=10 -p tests/userprog/open-normal:open-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'open-normal' | tests/userprog
+open-missing | --fs-disk=10 -p tests/userprog/open-missing:open-missing | -q   -f run | 'open-missing' | tests/userprog
+open-boundary | --fs-disk=10 -p tests/userprog/open-boundary:open-boundary -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'open-boundary' | tests/userprog
+open-empty | --fs-disk=10 -p tests/userprog/open-empty:open-empty | -q   -f run | 'open-empty' | tests/userprog
+open-null | --fs-disk=10 -p tests/userprog/open-null:open-null | -q   -f run | 'open-null' | tests/userprog
+open-bad-ptr | --fs-disk=10 -p tests/userprog/open-bad-ptr:open-bad-ptr | -q   -f run | 'open-bad-ptr' | tests/userprog
+open-twice | --fs-disk=10 -p tests/userprog/open-twice:open-twice -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'open-twice' | tests/userprog
+close-normal | --fs-disk=10 -p tests/userprog/close-normal:close-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'close-normal' | tests/userprog
+close-twice | --fs-disk=10 -p tests/userprog/close-twice:close-twice -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'close-twice' | tests/userprog
+close-bad-fd | --fs-disk=10 -p tests/userprog/close-bad-fd:close-bad-fd | -q   -f run | 'close-bad-fd' | tests/userprog
+read-normal | --fs-disk=10 -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-normal' | tests/userprog
+read-bad-ptr | --fs-disk=10 -p tests/userprog/read-bad-ptr:read-bad-ptr -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-bad-ptr' | tests/userprog
+read-boundary | --fs-disk=10 -p tests/userprog/read-boundary:read-boundary -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-boundary' | tests/userprog
+read-zero | --fs-disk=10 -p tests/userprog/read-zero:read-zero -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'read-zero' | tests/userprog
+read-stdout | --fs-disk=10 -p tests/userprog/read-stdout:read-stdout | -q   -f run | 'read-stdout' | tests/userprog
+read-bad-fd | --fs-disk=10 -p tests/userprog/read-bad-fd:read-bad-fd | -q   -f run | 'read-bad-fd' | tests/userprog
+write-normal | --fs-disk=10 -p tests/userprog/write-normal:write-normal -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-normal' | tests/userprog
+write-bad-ptr | --fs-disk=10 -p tests/userprog/write-bad-ptr:write-bad-ptr -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-bad-ptr' | tests/userprog
+write-boundary | --fs-disk=10 -p tests/userprog/write-boundary:write-boundary -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-boundary' | tests/userprog
+write-zero | --fs-disk=10 -p tests/userprog/write-zero:write-zero -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'write-zero' | tests/userprog
+write-stdin | --fs-disk=10 -p tests/userprog/write-stdin:write-stdin | -q   -f run | 'write-stdin' | tests/userprog
+write-bad-fd | --fs-disk=10 -p tests/userprog/write-bad-fd:write-bad-fd | -q   -f run | 'write-bad-fd' | tests/userprog
+fork-once | --fs-disk=10 -p tests/userprog/fork-once:fork-once | -q   -f run | 'fork-once' | tests/userprog
+fork-multiple | --fs-disk=10 -p tests/userprog/fork-multiple:fork-multiple | -q   -f run | 'fork-multiple' | tests/userprog
+fork-recursive | --fs-disk=10 -p tests/userprog/fork-recursive:fork-recursive | -q   -f run | 'fork-recursive' | tests/userprog
+fork-read | --fs-disk=10 -p tests/userprog/fork-read:fork-read -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'fork-read' | tests/userprog
+fork-close | --fs-disk=10 -p tests/userprog/fork-close:fork-close -p ../../tests/userprog/sample.txt:sample.txt | -q   -f run | 'fork-close' | tests/userprog
+fork-boundary | --fs-disk=10 -p tests/userprog/fork-boundary:fork-boundary | -q   -f run | 'fork-boundary' | tests/userprog
+exec-once | --fs-disk=10 -p tests/userprog/exec-once:exec-once -p tests/userprog/child-simple:child-simple | -q   -f run | 'exec-once' | tests/userprog
+exec-arg | --fs-disk=10 -p tests/userprog/exec-arg:exec-arg -p tests/userprog/child-args:child-args | -q   -f run | 'exec-arg' | tests/userprog
+exec-boundary | --fs-disk=10 -p tests/userprog/exec-boundary:exec-boundary -p tests/userprog/child-simple:child-simple | -q   -f run | 'exec-boundary' | tests/userprog
+exec-missing | --fs-disk=10 -p tests/userprog/exec-missing:exec-missing | -q   -f run | 'exec-missing' | tests/userprog
+exec-bad-ptr | --fs-disk=10 -p tests/userprog/exec-bad-ptr:exec-bad-ptr | -q   -f run | 'exec-bad-ptr' | tests/userprog
+exec-read | --fs-disk=10 -p tests/userprog/exec-read:exec-read -p ../../tests/userprog/sample.txt:sample.txt -p tests/userprog/child-read:child-read | -q   -f run | 'exec-read' | tests/userprog
+wait-simple | --fs-disk=10 -p tests/userprog/wait-simple:wait-simple -p tests/userprog/child-simple:child-simple | -q   -f run | 'wait-simple' | tests/userprog
+wait-twice | --fs-disk=10 -p tests/userprog/wait-twice:wait-twice -p tests/userprog/child-simple:child-simple | -q   -f run | 'wait-twice' | tests/userprog
+wait-killed | --fs-disk=10 -p tests/userprog/wait-killed:wait-killed -p tests/userprog/child-bad:child-bad | -q   -f run | 'wait-killed' | tests/userprog
+wait-bad-pid | --fs-disk=10 -p tests/userprog/wait-bad-pid:wait-bad-pid | -q   -f run | 'wait-bad-pid' | tests/userprog
+multi-recurse | --fs-disk=10 -p tests/userprog/multi-recurse:multi-recurse | -q   -f run | 'multi-recurse 15' | tests/userprog
+multi-child-fd | --fs-disk=10 -p tests/userprog/multi-child-fd:multi-child-fd -p ../../tests/userprog/sample.txt:sample.txt -p tests/userprog/child-close:child-close | -q   -f run | 'multi-child-fd' | tests/userprog
+rox-simple | --fs-disk=10 -p tests/userprog/rox-simple:rox-simple | -q   -f run | 'rox-simple' | tests/userprog
+rox-child | --fs-disk=10 -p tests/userprog/rox-child:rox-child -p tests/userprog/child-rox:child-rox | -q   -f run | 'rox-child' | tests/userprog
+rox-multichild | --fs-disk=10 -p tests/userprog/rox-multichild:rox-multichild -p tests/userprog/child-rox:child-rox | -q   -f run | 'rox-multichild' | tests/userprog
+bad-read | -T 30 --fs-disk=10 -p tests/userprog/bad-read:bad-read | -q   -f run | 'bad-read' | tests/userprog
+bad-write | --fs-disk=10 -p tests/userprog/bad-write:bad-write | -q   -f run | 'bad-write' | tests/userprog
+bad-read2 | --fs-disk=10 -p tests/userprog/bad-read2:bad-read2 | -q   -f run | 'bad-read2' | tests/userprog
+bad-write2 | --fs-disk=10 -p tests/userprog/bad-write2:bad-write2 | -q   -f run | 'bad-write2' | tests/userprog
+bad-jump | --fs-disk=10 -p tests/userprog/bad-jump:bad-jump | -q   -f run | 'bad-jump' | tests/userprog
+bad-jump2 | --fs-disk=10 -p tests/userprog/bad-jump2:bad-jump2 | -q   -f run | 'bad-jump2' | tests/userprog
+
+[filesys/base]
+lg-create | --fs-disk=10 -p tests/filesys/base/lg-create:lg-create | -q   -f run | 'lg-create' | tests/filesys/base
+lg-full | --fs-disk=10 -p tests/filesys/base/lg-full:lg-full | -q   -f run | 'lg-full' | tests/filesys/base
+lg-random | --fs-disk=10 -p tests/filesys/base/lg-random:lg-random | -q   -f run | 'lg-random' | tests/filesys/base
+lg-seq-block | --fs-disk=10 -p tests/filesys/base/lg-seq-block:lg-seq-block | -q   -f run | 'lg-seq-block' | tests/filesys/base
+lg-seq-random | --fs-disk=10 -p tests/filesys/base/lg-seq-random:lg-seq-random | -q   -f run | 'lg-seq-random' | tests/filesys/base
+sm-create | --fs-disk=10 -p tests/filesys/base/sm-create:sm-create | -q   -f run | 'sm-create' | tests/filesys/base
+sm-full | --fs-disk=10 -p tests/filesys/base/sm-full:sm-full | -q   -f run | 'sm-full' | tests/filesys/base
+sm-random | --fs-disk=10 -p tests/filesys/base/sm-random:sm-random | -q   -f run | 'sm-random' | tests/filesys/base
+sm-seq-block | --fs-disk=10 -p tests/filesys/base/sm-seq-block:sm-seq-block | -q   -f run | 'sm-seq-block' | tests/filesys/base
+sm-seq-random | --fs-disk=10 -p tests/filesys/base/sm-seq-random:sm-seq-random | -q   -f run | 'sm-seq-random' | tests/filesys/base
+syn-read | --fs-disk=10 -p tests/filesys/base/syn-read:syn-read -p tests/filesys/base/child-syn-read:child-syn-read | -q   -f run | 'syn-read' | tests/filesys/base
+syn-remove | --fs-disk=10 -p tests/filesys/base/syn-remove:syn-remove | -q   -f run | 'syn-remove' | tests/filesys/base
+syn-write | --fs-disk=10 -p tests/filesys/base/syn-write:syn-write -p tests/filesys/base/child-syn-wrt:child-syn-wrt | -q   -f run | 'syn-write' | tests/filesys/base
+
+[userprog/no-vm]
+multi-oom | -T 600 -k -v -m 20 -m 20 --fs-disk=10 -p tests/userprog/no-vm/multi-oom:multi-oom | -q   -f run | 'multi-oom' | tests/userprog/no-vm
+
+[threads]
+alarm-single | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-single' | tests/threads
+alarm-multiple | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-multiple' | tests/threads
+alarm-simultaneous | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-simultaneous' | tests/threads
+alarm-priority | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-priority' | tests/threads
+alarm-zero | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-zero' | tests/threads
+alarm-negative | --fs-disk=10 | -q  -threads-tests -f run | 'alarm-negative' | tests/threads
+priority-change | --fs-disk=10 | -q  -threads-tests -f run | 'priority-change' | tests/threads
+priority-donate-one | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-one' | tests/threads
+priority-donate-multiple | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-multiple' | tests/threads
+priority-donate-multiple2 | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-multiple2' | tests/threads
+priority-donate-nest | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-nest' | tests/threads
+priority-donate-sema | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-sema' | tests/threads
+priority-donate-lower | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-lower' | tests/threads
+priority-fifo | --fs-disk=10 | -q  -threads-tests -f run | 'priority-fifo' | tests/threads
+priority-preempt | --fs-disk=10 | -q  -threads-tests -f run | 'priority-preempt' | tests/threads
+priority-sema | --fs-disk=10 | -q  -threads-tests -f run | 'priority-sema' | tests/threads
+priority-condvar | --fs-disk=10 | -q  -threads-tests -f run | 'priority-condvar' | tests/threads
+priority-donate-chain | --fs-disk=10 | -q  -threads-tests -f run | 'priority-donate-chain' | tests/threads
+
+[extra]
+dup2-simple  | --fs-disk=10 -p tests/userprog/dup2/dup2-simple:dup2-simple -p ../../tests/userprog/dup2/sample.txt:sample.txt   | -q -f run | 'dup2-simple'   | tests/userprog/dup2
+dup2-complex | --fs-disk=10 -p tests/userprog/dup2/dup2-complex:dup2-complex -p ../../tests/userprog/dup2/sample.txt:sample.txt | -q   -f run | 'dup2-complex' | tests/userprog/dup2
+
+
+# Total testcases: 97
+# Generated on 2025-07-29

--- a/pintos/userprog/.test_status
+++ b/pintos/userprog/.test_status
@@ -1,0 +1,1 @@
+args-none FAIL

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -29,9 +29,8 @@ static void __do_fork(void*);
 
 /* General process initializer for initd and other process. */
 static void
-process_init(void)
-{
-    struct thread* current = thread_current();
+process_init(void) {
+  struct thread* current = thread_current();
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.
@@ -40,81 +39,76 @@ process_init(void)
  * thread id, or TID_ERROR if the thread cannot be created.
  * Notice that THIS SHOULD BE CALLED ONCE. */
 tid_t
-process_create_initd(const char* file_name)
-{
-    char* fn_copy;
-    tid_t tid;
+process_create_initd(const char* file_name) {
+  char* fn_copy;
+  tid_t tid;
 
-    /* Make a copy of FILE_NAME.
-     * Otherwise there's a race between the caller and load(). */
-    fn_copy = palloc_get_page(0);
-    if (fn_copy == NULL)
-        return TID_ERROR;
-    strlcpy(fn_copy, file_name, PGSIZE);
+  /* Make a copy of FILE_NAME.
+   * Otherwise there's a race between the caller and load(). */
+  fn_copy = palloc_get_page(0);
+  if (fn_copy == NULL)
+    return TID_ERROR;
+  strlcpy(fn_copy, file_name, PGSIZE);
 
-    /* Create a new thread to execute FILE_NAME. */
-    tid = thread_create(file_name, PRI_DEFAULT, initd, fn_copy);
-    if (tid == TID_ERROR)
-        palloc_free_page(fn_copy);
-    return tid;
+  /* Create a new thread to execute FILE_NAME. */
+  tid = thread_create(file_name, PRI_DEFAULT, initd, fn_copy);
+  if (tid == TID_ERROR)
+    palloc_free_page(fn_copy);
+  return tid;
 }
 
 /* A thread function that launches first user process. */
 static void
-initd(void* f_name)
-{
+initd(void* f_name) {
 #ifdef VM
-    supplemental_page_table_init(&thread_current()->spt);
+  supplemental_page_table_init(&thread_current()->spt);
 #endif
 
-    process_init();
+  process_init();
 
-    if (process_exec(f_name) < 0)
-        PANIC("Fail to launch initd\n");
-    NOT_REACHED();
+  if (process_exec(f_name) < 0)
+    PANIC("Fail to launch initd\n");
+  NOT_REACHED();
 }
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
 tid_t
-process_fork(const char* name, struct intr_frame* if_ UNUSED)
-{
-    /* Clone current thread to new thread.*/
-    return thread_create(name,
-                         PRI_DEFAULT, __do_fork, thread_current());
+process_fork(const char* name, struct intr_frame* if_ UNUSED) {
+  /* Clone current thread to new thread.*/
+  return thread_create(name,
+                       PRI_DEFAULT, __do_fork, thread_current());
 }
 
 #ifndef VM
 /* Duplicate the parent's address space by passing this function to the
  * pml4_for_each. This is only for the project 2. */
 static bool
-duplicate_pte(uint64_t* pte, void* va, void* aux)
-{
-    struct thread* current = thread_current();
-    struct thread* parent = (struct thread*)aux;
-    void* parent_page;
-    void* newpage;
-    bool writable;
+duplicate_pte(uint64_t* pte, void* va, void* aux) {
+  struct thread* current = thread_current();
+  struct thread* parent = (struct thread*)aux;
+  void* parent_page;
+  void* newpage;
+  bool writable;
 
-    /* 1. TODO: If the parent_page is kernel page, then return immediately. */
+  /* 1. TODO: If the parent_page is kernel page, then return immediately. */
 
-    /* 2. Resolve VA from the parent's page map level 4. */
-    parent_page = pml4_get_page(parent->pml4, va);
+  /* 2. Resolve VA from the parent's page map level 4. */
+  parent_page = pml4_get_page(parent->pml4, va);
 
-    /* 3. TODO: Allocate new PAL_USER page for the child and set result to
-     *    TODO: NEWPAGE. */
+  /* 3. TODO: Allocate new PAL_USER page for the child and set result to
+   *    TODO: NEWPAGE. */
 
-    /* 4. TODO: Duplicate parent's page to the new page and
-     *    TODO: check whether parent's page is writable or not (set WRITABLE
-     *    TODO: according to the result). */
+  /* 4. TODO: Duplicate parent's page to the new page and
+   *    TODO: check whether parent's page is writable or not (set WRITABLE
+   *    TODO: according to the result). */
 
-    /* 5. Add new page to child's page table at address VA with WRITABLE
-     *    permission. */
-    if (!pml4_set_page(current->pml4, va, newpage, writable))
-    {
-        /* 6. TODO: if fail to insert page, do error handling. */
-    }
-    return true;
+  /* 5. Add new page to child's page table at address VA with WRITABLE
+   *    permission. */
+  if (!pml4_set_page(current->pml4, va, newpage, writable)) {
+    /* 6. TODO: if fail to insert page, do error handling. */
+  }
+  return true;
 }
 #endif
 
@@ -123,96 +117,92 @@ duplicate_pte(uint64_t* pte, void* va, void* aux)
  *       That is, you are required to pass second argument of process_fork to
  *       this function. */
 static void
-__do_fork(void* aux)
-{
-    struct intr_frame if_;
-    struct thread* parent = (struct thread*)aux;
-    struct thread* current = thread_current();
-    /* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
-    struct intr_frame* parent_if;
-    bool succ = true;
+__do_fork(void* aux) {
+  struct intr_frame if_;
+  struct thread* parent = (struct thread*)aux;
+  struct thread* current = thread_current();
+  /* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
+  struct intr_frame* parent_if;
+  bool succ = true;
 
-    /* 1. Read the cpu context to local stack. */
-    memcpy(&if_, parent_if, sizeof(struct intr_frame));
+  /* 1. Read the cpu context to local stack. */
+  memcpy(&if_, parent_if, sizeof(struct intr_frame));
 
-    /* 2. Duplicate PT */
-    current->pml4 = pml4_create();
-    if (current->pml4 == NULL)
-        goto error;
+  /* 2. Duplicate PT */
+  current->pml4 = pml4_create();
+  if (current->pml4 == NULL)
+    goto error;
 
-    process_activate(current);
+  process_activate(current);
 #ifdef VM
-    supplemental_page_table_init(&current->spt);
-    if (!supplemental_page_table_copy(&current->spt, &parent->spt))
-        goto error;
+  supplemental_page_table_init(&current->spt);
+  if (!supplemental_page_table_copy(&current->spt, &parent->spt))
+    goto error;
 #else
-    if (!pml4_for_each(parent->pml4, duplicate_pte, parent))
-        goto error;
+  if (!pml4_for_each(parent->pml4, duplicate_pte, parent))
+    goto error;
 #endif
 
-    /* TODO: Your code goes here.
-     * TODO: Hint) To duplicate the file object, use `file_duplicate`
-     * TODO:       in include/filesys/file.h. Note that parent should not return
-     * TODO:       from the fork() until this function successfully duplicates
-     * TODO:       the resources of parent.*/
+  /* TODO: Your code goes here.
+   * TODO: Hint) To duplicate the file object, use `file_duplicate`
+   * TODO:       in include/filesys/file.h. Note that parent should not return
+   * TODO:       from the fork() until this function successfully duplicates
+   * TODO:       the resources of parent.*/
 
-    process_init();
+  process_init();
 
-    /* Finally, switch to the newly created process. */
-    if (succ)
-        do_iret(&if_);
+  /* Finally, switch to the newly created process. */
+  if (succ)
+    do_iret(&if_);
 error:
-    thread_exit();
+  thread_exit();
 }
 
 /* Switch the current execution context to the f_name.
  * Returns -1 on fail. */
-int process_exec(void* cmd_args)
-{
-    char* command_line = (char*)cmd_args;
-    char *save_ptr;
-    char *argv[128]; // argument 포인터들을 저장할 배열
-    int argc = 0; // 0부터 시작
-    char* cmd = palloc_get_page(0);
+int process_exec(void* cmd_args) {
+  char* command_line = (char*)cmd_args;
+  char* save_ptr;
+  char* argv[128]; // argument 포인터들을 저장할 배열
+  int argc = 0; // 0부터 시작
+  char* cmd = palloc_get_page(0);
 
-    strlcpy(cmd, command_line, PGSIZE);
-    char* token = strtok_r(cmd, " ", &save_ptr);
-    while (token != NULL && argc < 127)
-    {
-        argv[argc] = token;
-        argc++;
-        token = strtok_r(NULL, " ", &save_ptr);
-    }
-    argv[argc] = NULL; // argv 배열은 반드시 NULL로 끝나야 한다.
+  strlcpy(cmd, command_line, PGSIZE);
+  char* token = strtok_r(cmd, " ", &save_ptr);
+  while (token != NULL && argc < 127) {
+    argv[argc] = token;
+    argc++;
+    token = strtok_r(NULL, " ", &save_ptr);
+  }
+  argv[argc] = NULL; // argv 배열은 반드시 NULL로 끝나야 한다.
 
-    char* file_name = cmd_args;
-    bool success;
+  char* file_name = argv[0];
+  bool success;
 
-    printf("process_exec: %s\n", file_name);
+  printf("process_exec: %s\n", file_name);
 
-    /* We cannot use the intr_frame in the thread structure.
-     * This is because when current thread rescheduled,
-     * it stores the execution information to the member. */
-    struct intr_frame _if;
-    _if.
-    _if.ds = _if.es = _if.ss = SEL_UDSEG;
-    _if.cs = SEL_UCSEG;
-    _if.eflags = FLAG_IF | FLAG_MBS;
+  /* We cannot use the intr_frame in the thread structure.
+   * This is because when current thread rescheduled,
+   * it stores the execution information to the member. */
+  struct intr_frame _if;
+  _if.ds = _if.es = _if.ss = SEL_UDSEG;
+  _if.cs = SEL_UCSEG;
+  _if.eflags = FLAG_IF | FLAG_MBS;
 
-    /* We first kill the current context */
-    process_cleanup();
+  /* We first kill the current context */
+  process_cleanup();
 
-    /* And then load the binary */
-    success = load(argv, &_if);
+  /* And then load the binary */
+  success = load(argv, &_if);
 
-    /* If load failed, quit. */
-    palloc_free_page(file_name);
-    if (!success)
-        return -1;
+  /* If load failed, quit. */
+  palloc_free_page(cmd);
+  if (!success)
+    return -1;
 
-    /* Start switched process. */
-    do_iret(&_if);
-    NOT_REACHED();
+  /* Start switched process. */
+  do_iret(&_if);
+  NOT_REACHED();
 }
 
 
@@ -226,66 +216,64 @@ int process_exec(void* cmd_args)
  * This function will be implemented in problem 2-2.  For now, it
  * does nothing. */
 int
-process_wait(tid_t child_tid UNUSED)
-{
-    /* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
-     * XXX:       to add infinite loop here before
-     * XXX:       implementing the process_wait. */
-    return -1;
+process_wait(tid_t child_tid UNUSED) {
+  /* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
+   * XXX:       to add infinite loop here before
+   * XXX:       implementing the process_wait. */
+  while (1) {
+    
+  }
+  return -1;
 }
 
 /* Exit the process. This function is called by thread_exit (). */
 void
-process_exit(void)
-{
-    struct thread* curr = thread_current();
-    /* TODO: Your code goes here.
-     * TODO: Implement process termination message (see
-     * TODO: project2/process_termination.html).
-     * TODO: We recommend you to implement process resource cleanup here. */
+process_exit(void) {
+  struct thread* curr = thread_current();
+  /* TODO: Your code goes here.
+   * TODO: Implement process termination message (see
+   * TODO: project2/process_termination.html).
+   * TODO: We recommend you to implement process resource cleanup here. */
 
-    process_cleanup();
+  process_cleanup();
 }
 
 /* Free the current process's resources. */
 static void
-process_cleanup(void)
-{
-    struct thread* curr = thread_current();
+process_cleanup(void) {
+  struct thread* curr = thread_current();
 
 #ifdef VM
-    supplemental_page_table_kill(&curr->spt);
+  supplemental_page_table_kill(&curr->spt);
 #endif
 
-    uint64_t* pml4;
-    /* Destroy the current process's page directory and switch back
-     * to the kernel-only page directory. */
-    pml4 = curr->pml4;
-    if (pml4 != NULL)
-    {
-        /* Correct ordering here is crucial.  We must set
-         * cur->pagedir to NULL before switching page directories,
-         * so that a timer interrupt can't switch back to the
-         * process page directory.  We must activate the base page
-         * directory before destroying the process's page
-         * directory, or our active page directory will be one
-         * that's been freed (and cleared). */
-        curr->pml4 = NULL;
-        pml4_activate(NULL);
-        pml4_destroy(pml4);
-    }
+  uint64_t* pml4;
+  /* Destroy the current process's page directory and switch back
+   * to the kernel-only page directory. */
+  pml4 = curr->pml4;
+  if (pml4 != NULL) {
+    /* Correct ordering here is crucial.  We must set
+     * cur->pagedir to NULL before switching page directories,
+     * so that a timer interrupt can't switch back to the
+     * process page directory.  We must activate the base page
+     * directory before destroying the process's page
+     * directory, or our active page directory will be one
+     * that's been freed (and cleared). */
+    curr->pml4 = NULL;
+    pml4_activate(NULL);
+    pml4_destroy(pml4);
+  }
 }
 
 /* Sets up the CPU for running user code in the nest thread.
  * This function is called on every context switch. */
 void
-process_activate(struct thread* next)
-{
-    /* Activate thread's page tables. */
-    pml4_activate(next->pml4);
+process_activate(struct thread* next) {
+  /* Activate thread's page tables. */
+  pml4_activate(next->pml4);
 
-    /* Set thread's kernel stack for use in processing interrupts. */
-    tss_update(next);
+  /* Set thread's kernel stack for use in processing interrupts. */
+  tss_update(next);
 }
 
 /* We load ELF binaries.  The following definitions are taken
@@ -309,34 +297,32 @@ process_activate(struct thread* next)
 
 /* Executable header.  See [ELF1] 1-4 to 1-8.
  * This appears at the very beginning of an ELF binary. */
-struct ELF64_hdr
-{
-    unsigned char e_ident[EI_NIDENT];
-    uint16_t e_type;
-    uint16_t e_machine;
-    uint32_t e_version;
-    uint64_t e_entry;
-    uint64_t e_phoff;
-    uint64_t e_shoff;
-    uint32_t e_flags;
-    uint16_t e_ehsize;
-    uint16_t e_phentsize;
-    uint16_t e_phnum;
-    uint16_t e_shentsize;
-    uint16_t e_shnum;
-    uint16_t e_shstrndx;
+struct ELF64_hdr {
+  unsigned char e_ident[EI_NIDENT];
+  uint16_t e_type;
+  uint16_t e_machine;
+  uint32_t e_version;
+  uint64_t e_entry;
+  uint64_t e_phoff;
+  uint64_t e_shoff;
+  uint32_t e_flags;
+  uint16_t e_ehsize;
+  uint16_t e_phentsize;
+  uint16_t e_phnum;
+  uint16_t e_shentsize;
+  uint16_t e_shnum;
+  uint16_t e_shstrndx;
 };
 
-struct ELF64_PHDR
-{
-    uint32_t p_type;
-    uint32_t p_flags;
-    uint64_t p_offset;
-    uint64_t p_vaddr;
-    uint64_t p_paddr;
-    uint64_t p_filesz;
-    uint64_t p_memsz;
-    uint64_t p_align;
+struct ELF64_PHDR {
+  uint32_t p_type;
+  uint32_t p_flags;
+  uint64_t p_offset;
+  uint64_t p_vaddr;
+  uint64_t p_paddr;
+  uint64_t p_filesz;
+  uint64_t p_memsz;
+  uint64_t p_align;
 };
 
 /* Abbreviations */
@@ -353,165 +339,192 @@ static bool load_segment(struct file* file, off_t ofs, uint8_t* upage,
  * Stores the executable's entry point into *RIP
  * and its initial stack pointer into *RSP.
  * Returns true if successful, false otherwise. */
-static bool load(char* argv[], struct intr_frame* if_)
-{
-    struct thread* t = thread_current();
-    struct ELF ehdr;
-    struct file* file = NULL;
-    off_t file_ofs;
-    bool success = false;
-    int i;
-    char* file_name = argv[0];
+static bool load(char* argv[], struct intr_frame* if_) {
+  struct thread* t = thread_current();
+  struct ELF ehdr;
+  struct file* file = NULL;
+  off_t file_ofs;
+  bool success = false;
+  char* file_name = argv[0];
 
-    /* Allocate and activate page directory. */
-    t->pml4 = pml4_create();
-    if (t->pml4 == NULL)
+  /* Allocate and activate page directory. */
+  t->pml4 = pml4_create();
+  if (t->pml4 == NULL)
+    goto done;
+  process_activate(thread_current());
+
+  /* Open executable file. */
+  file = filesys_open(file_name);
+  if (file == NULL) {
+    printf("load: %s: open failed\n", file_name);
+    goto done;
+  }
+
+  /* Read and verify executable header. */
+  if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr
+      || memcmp(ehdr.e_ident, "\177ELF\2\1\1", 7)
+      || ehdr.e_type != 2
+      || ehdr.e_machine != 0x3E // amd64
+      || ehdr.e_version != 1
+      || ehdr.e_phentsize != sizeof(struct Phdr)
+      || ehdr.e_phnum > 1024) {
+    printf("load: %s: error loading executable\n", file_name);
+    goto done;
+  }
+
+  /* Read program headers. */
+  file_ofs = ehdr.e_phoff;
+  for (int i = 0; i < ehdr.e_phnum; i++) {
+    struct Phdr phdr;
+
+    if (file_ofs < 0 || file_ofs > file_length(file))
+      goto done;
+    file_seek(file, file_ofs);
+
+    if (file_read(file, &phdr, sizeof phdr) != sizeof phdr)
+      goto done;
+    file_ofs += sizeof phdr;
+    switch (phdr.p_type) {
+      case PT_NULL:
+      case PT_NOTE:
+      case PT_PHDR:
+      case PT_STACK:
+      default:
+        /* Ignore this segment. */
+        break;
+      case PT_DYNAMIC:
+      case PT_INTERP:
+      case PT_SHLIB:
         goto done;
-    process_activate(thread_current());
-
-    /* Open executable file. */
-    file = filesys_open(file_name);
-    if (file == NULL)
-    {
-        printf("load: %s: open failed\n", file_name);
-        goto done;
-    }
-
-    /* Read and verify executable header. */
-    if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr
-        || memcmp(ehdr.e_ident, "\177ELF\2\1\1", 7)
-        || ehdr.e_type != 2
-        || ehdr.e_machine != 0x3E // amd64
-        || ehdr.e_version != 1
-        || ehdr.e_phentsize != sizeof(struct Phdr)
-        || ehdr.e_phnum > 1024)
-    {
-        printf("load: %s: error loading executable\n", file_name);
-        goto done;
-    }
-
-    /* Read program headers. */
-    file_ofs = ehdr.e_phoff;
-    for (i = 0; i < ehdr.e_phnum; i++)
-    {
-        struct Phdr phdr;
-
-        if (file_ofs < 0 || file_ofs > file_length(file))
+      case PT_LOAD:
+        if (validate_segment(&phdr, file)) {
+          bool writable = (phdr.p_flags & PF_W) != 0;
+          uint64_t file_page = phdr.p_offset & ~PGMASK;
+          uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
+          uint64_t page_offset = phdr.p_vaddr & PGMASK;
+          uint32_t read_bytes, zero_bytes;
+          if (phdr.p_filesz > 0) {
+            /* Normal segment.
+             * Read initial part from disk and zero the rest. */
+            read_bytes = page_offset + phdr.p_filesz;
+            zero_bytes = (ROUND_UP(page_offset + phdr.p_memsz, PGSIZE)
+                          - read_bytes);
+          } else {
+            /* Entirely zero.
+             * Don't read anything from disk. */
+            read_bytes = 0;
+            zero_bytes = ROUND_UP(page_offset + phdr.p_memsz, PGSIZE);
+          }
+          if (!load_segment(file, file_page, (void*)mem_page,
+                            read_bytes, zero_bytes, writable))
             goto done;
-        file_seek(file, file_ofs);
-
-        if (file_read(file, &phdr, sizeof phdr) != sizeof phdr)
-            goto done;
-        file_ofs += sizeof phdr;
-        switch (phdr.p_type)
-        {
-        case PT_NULL:
-        case PT_NOTE:
-        case PT_PHDR:
-        case PT_STACK:
-        default:
-            /* Ignore this segment. */
-            break;
-        case PT_DYNAMIC:
-        case PT_INTERP:
-        case PT_SHLIB:
-            goto done;
-        case PT_LOAD:
-            if (validate_segment(&phdr, file))
-            {
-                bool writable = (phdr.p_flags & PF_W) != 0;
-                uint64_t file_page = phdr.p_offset & ~PGMASK;
-                uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
-                uint64_t page_offset = phdr.p_vaddr & PGMASK;
-                uint32_t read_bytes, zero_bytes;
-                if (phdr.p_filesz > 0)
-                {
-                    /* Normal segment.
-                     * Read initial part from disk and zero the rest. */
-                    read_bytes = page_offset + phdr.p_filesz;
-                    zero_bytes = (ROUND_UP(page_offset + phdr.p_memsz, PGSIZE)
-                        - read_bytes);
-                }
-                else
-                {
-                    /* Entirely zero.
-                     * Don't read anything from disk. */
-                    read_bytes = 0;
-                    zero_bytes = ROUND_UP(page_offset + phdr.p_memsz, PGSIZE);
-                }
-                if (!load_segment(file, file_page, (void*)mem_page,
-                                  read_bytes, zero_bytes, writable))
-                    goto done;
-            }
-            else
-                goto done;
-            break;
-        }
+        } else
+          goto done;
+        break;
     }
+  }
 
-    /* Set up stack. */
-    if (!setup_stack(if_))
-        goto done;
+  /* Set up stack. */
+  if (!setup_stack(if_))
+    goto done;
 
-    /* Start address. */
-    if_->rip = ehdr.e_entry;
+  /* Start address. */
+  if_->rip = ehdr.e_entry;
 
-    /* TODO: Your code goes here.
-     * TODO: Implement argument passing (see project2/argument_passing.html). */
+  char* arg_address[128];
+  char* stack_ptr = (char*)if_->rsp;
+
+  int argc = 0;
+  while (argv[argc] != NULL) {
+    argc++;
+  }
+
+  for (int i = argc - 1; i >= 0; i--) {
+    int len = (int)strnlen(argv[i], PGSIZE) + 1;
+    stack_ptr -= len;
+    memcpy(stack_ptr, argv[i], len);
+    arg_address[i] = stack_ptr;
+  }
+
+  // word alignment (8바이트 정렬)
+  uintptr_t stack_addr = (uintptr_t)stack_ptr;
+  stack_addr &= ~(8 - 1);
+  stack_ptr = (char*)stack_addr;
+
+  // argv 포인터 배열 만들기.
+  stack_ptr -= sizeof(char*); // 8바이트 감소.
+  *(char**)stack_ptr = NULL; // 8바이트 감소한 주소의 위치에 NULL 포인터 저장
+
+  // argv[argc-1]부터 argv[0]까지
+  for (int i = argc - 1; i >= 0; i--) {
+    stack_ptr -= sizeof(char*);
+    *(char**)stack_ptr = arg_address[i];
+  }
+  void *argv_base = (void *)stack_ptr;  // 포인터 배열의 시작 주소
+
+  // Align stack pointer to 16 bytes for the System V ABI.
+  int padding = (uintptr_t)stack_ptr % 16;
+  if (padding != 0) {
+    stack_ptr -= padding;
+    memset(stack_ptr, 0, padding);
+  }
+
+  if_->R.rdi = argc;
+  if_->R.rsi = (uintptr_t)argv_base;
+  if_->rsp = (uintptr_t)stack_ptr;
 
 
-    success = true;
+  success = true;
 
 done:
-    /* We arrive here whether the load is successful or not. */
-    file_close(file);
-    return success;
+  /* We arrive here whether the load is successful or not. */
+  file_close(file);
+  return success;
 }
 
 
 /* Checks whether PHDR describes a valid, loadable segment in
  * FILE and returns true if so, false otherwise. */
 static bool
-validate_segment(const struct Phdr* phdr, struct file* file)
-{
-    /* p_offset and p_vaddr must have the same page offset. */
-    if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
-        return false;
+validate_segment(const struct Phdr* phdr, struct file* file) {
+  /* p_offset and p_vaddr must have the same page offset. */
+  if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
+    return false;
 
-    /* p_offset must point within FILE. */
-    if (phdr->p_offset > (uint64_t)file_length(file))
-        return false;
+  /* p_offset must point within FILE. */
+  if (phdr->p_offset > (uint64_t)file_length(file))
+    return false;
 
-    /* p_memsz must be at least as big as p_filesz. */
-    if (phdr->p_memsz < phdr->p_filesz)
-        return false;
+  /* p_memsz must be at least as big as p_filesz. */
+  if (phdr->p_memsz < phdr->p_filesz)
+    return false;
 
-    /* The segment must not be empty. */
-    if (phdr->p_memsz == 0)
-        return false;
+  /* The segment must not be empty. */
+  if (phdr->p_memsz == 0)
+    return false;
 
-    /* The virtual memory region must both start and end within the
-       user address space range. */
-    if (!is_user_vaddr((void *) phdr->p_vaddr))
-        return false;
-    if (!is_user_vaddr((void *) (phdr->p_vaddr + phdr->p_memsz)))
-        return false;
+  /* The virtual memory region must both start and end within the
+     user address space range. */
+  if (!is_user_vaddr((void *) phdr->p_vaddr))
+    return false;
+  if (!is_user_vaddr((void *) (phdr->p_vaddr + phdr->p_memsz)))
+    return false;
 
-    /* The region cannot "wrap around" across the kernel virtual
-       address space. */
-    if (phdr->p_vaddr + phdr->p_memsz < phdr->p_vaddr)
-        return false;
+  /* The region cannot "wrap around" across the kernel virtual
+     address space. */
+  if (phdr->p_vaddr + phdr->p_memsz < phdr->p_vaddr)
+    return false;
 
-    /* Disallow mapping page 0.
-       Not only is it a bad idea to map page 0, but if we allowed
-       it then user code that passed a null pointer to system calls
-       could quite likely panic the kernel by way of null pointer
-       assertions in memcpy(), etc. */
-    if (phdr->p_vaddr < PGSIZE)
-        return false;
+  /* Disallow mapping page 0.
+     Not only is it a bad idea to map page 0, but if we allowed
+     it then user code that passed a null pointer to system calls
+     could quite likely panic the kernel by way of null pointer
+     assertions in memcpy(), etc. */
+  if (phdr->p_vaddr < PGSIZE)
+    return false;
 
-    /* It's okay. */
-    return true;
+  /* It's okay. */
+  return true;
 }
 
 #ifndef VM
@@ -538,67 +551,61 @@ static bool install_page(void* upage, void* kpage, bool writable);
  * or disk read error occurs. */
 static bool
 load_segment(struct file* file, off_t ofs, uint8_t* upage,
-             uint32_t read_bytes, uint32_t zero_bytes, bool writable)
-{
-    ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
-    ASSERT(pg_ofs (upage) == 0);
-    ASSERT(ofs % PGSIZE == 0);
+             uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
+  ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+  ASSERT(pg_ofs (upage) == 0);
+  ASSERT(ofs % PGSIZE == 0);
 
-    file_seek(file, ofs);
-    while (read_bytes > 0 || zero_bytes > 0)
-    {
-        /* Do calculate how to fill this page.
-         * We will read PAGE_READ_BYTES bytes from FILE
-         * and zero the final PAGE_ZERO_BYTES bytes. */
-        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
-        size_t page_zero_bytes = PGSIZE - page_read_bytes;
+  file_seek(file, ofs);
+  while (read_bytes > 0 || zero_bytes > 0) {
+    /* Do calculate how to fill this page.
+     * We will read PAGE_READ_BYTES bytes from FILE
+     * and zero the final PAGE_ZERO_BYTES bytes. */
+    size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+    size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-        /* Get a page of memory. */
-        uint8_t* kpage = palloc_get_page(PAL_USER);
-        if (kpage == NULL)
-            return false;
+    /* Get a page of memory. */
+    uint8_t* kpage = palloc_get_page(PAL_USER);
+    if (kpage == NULL)
+      return false;
 
-        /* Load this page. */
-        if (file_read(file, kpage, page_read_bytes) != (int)page_read_bytes)
-        {
-            palloc_free_page(kpage);
-            return false;
-        }
-        memset(kpage + page_read_bytes, 0, page_zero_bytes);
-
-        /* Add the page to the process's address space. */
-        if (!install_page(upage, kpage, writable))
-        {
-            printf("fail\n");
-            palloc_free_page(kpage);
-            return false;
-        }
-
-        /* Advance. */
-        read_bytes -= page_read_bytes;
-        zero_bytes -= page_zero_bytes;
-        upage += PGSIZE;
+    /* Load this page. */
+    if (file_read(file, kpage, page_read_bytes) != (int)page_read_bytes) {
+      palloc_free_page(kpage);
+      return false;
     }
-    return true;
+    memset(kpage + page_read_bytes, 0, page_zero_bytes);
+
+    /* Add the page to the process's address space. */
+    if (!install_page(upage, kpage, writable)) {
+      printf("fail\n");
+      palloc_free_page(kpage);
+      return false;
+    }
+
+    /* Advance. */
+    read_bytes -= page_read_bytes;
+    zero_bytes -= page_zero_bytes;
+    upage += PGSIZE;
+  }
+  return true;
 }
 
 /* Create a minimal stack by mapping a zeroed page at the USER_STACK */
 static bool
-setup_stack(struct intr_frame* if_)
-{
-    uint8_t* kpage;
-    bool success = false;
+setup_stack(struct intr_frame* if_) {
+  uint8_t* kpage;
+  bool success = false;
 
-    kpage = palloc_get_page(PAL_USER | PAL_ZERO);
-    if (kpage != NULL)
-    {
-        success = install_page(((uint8_t*)USER_STACK) - PGSIZE, kpage, true);
-        if (success)
-            if_->rsp = USER_STACK;
-        else
-            palloc_free_page(kpage);
-    }
-    return success;
+  kpage = palloc_get_page(PAL_USER | PAL_ZERO);
+  if (kpage != NULL) {
+    success = install_page(((uint8_t*)USER_STACK) - PGSIZE, kpage, true);
+    if (success)
+      if_->rsp = USER_STACK;
+    else
+      palloc_free_page(kpage);
+  }
+  return success;
 }
 
 /* Adds a mapping from user virtual address UPAGE to kernel
@@ -611,14 +618,13 @@ setup_stack(struct intr_frame* if_)
  * Returns true on success, false if UPAGE is already mapped or
  * if memory allocation fails. */
 static bool
-install_page(void* upage, void* kpage, bool writable)
-{
-    struct thread* t = thread_current();
+install_page(void* upage, void* kpage, bool writable) {
+  struct thread* t = thread_current();
 
-    /* Verify that there's not already a page at that virtual
-     * address, then map our page there. */
-    return (pml4_get_page(t->pml4, upage) == NULL
-        && pml4_set_page(t->pml4, upage, kpage, writable));
+  /* Verify that there's not already a page at that virtual
+   * address, then map our page there. */
+  return (pml4_get_page(t->pml4, upage) == NULL
+          && pml4_set_page(t->pml4, upage, kpage, writable));
 }
 #else
 /* From here, codes will be used after project 3.
@@ -626,11 +632,10 @@ install_page(void* upage, void* kpage, bool writable)
  * upper block. */
 
 static bool
-lazy_load_segment(struct page* page, void* aux)
-{
-    /* TODO: Load the segment from the file */
-    /* TODO: This called when the first page fault occurs on address VA. */
-    /* TODO: VA is available when calling this function. */
+lazy_load_segment(struct page* page, void* aux) {
+  /* TODO: Load the segment from the file */
+  /* TODO: This called when the first page fault occurs on address VA. */
+  /* TODO: VA is available when calling this function. */
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -649,46 +654,43 @@ lazy_load_segment(struct page* page, void* aux)
  * or disk read error occurs. */
 static bool
 load_segment(struct file* file, off_t ofs, uint8_t* upage,
-             uint32_t read_bytes, uint32_t zero_bytes, bool writable)
-{
-    ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
-    ASSERT(pg_ofs(upage) == 0);
-    ASSERT(ofs % PGSIZE == 0);
+             uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
+  ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+  ASSERT(pg_ofs(upage) == 0);
+  ASSERT(ofs % PGSIZE == 0);
 
-    while (read_bytes > 0 || zero_bytes > 0)
-    {
-        /* Do calculate how to fill this page.
-         * We will read PAGE_READ_BYTES bytes from FILE
-         * and zero the final PAGE_ZERO_BYTES bytes. */
-        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
-        size_t page_zero_bytes = PGSIZE - page_read_bytes;
+  while (read_bytes > 0 || zero_bytes > 0) {
+    /* Do calculate how to fill this page.
+     * We will read PAGE_READ_BYTES bytes from FILE
+     * and zero the final PAGE_ZERO_BYTES bytes. */
+    size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+    size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-        /* TODO: Set up aux to pass information to the lazy_load_segment. */
-        void* aux = NULL;
-        if (!vm_alloc_page_with_initializer(VM_ANON, upage,
-                                            writable, lazy_load_segment, aux))
-            return false;
+    /* TODO: Set up aux to pass information to the lazy_load_segment. */
+    void* aux = NULL;
+    if (!vm_alloc_page_with_initializer(VM_ANON, upage,
+                                        writable, lazy_load_segment, aux))
+      return false;
 
-        /* Advance. */
-        read_bytes -= page_read_bytes;
-        zero_bytes -= page_zero_bytes;
-        upage += PGSIZE;
-    }
-    return true;
+    /* Advance. */
+    read_bytes -= page_read_bytes;
+    zero_bytes -= page_zero_bytes;
+    upage += PGSIZE;
+  }
+  return true;
 }
 
 /* Create a PAGE of stack at the USER_STACK. Return true on success. */
 static bool
-setup_stack(struct intr_frame* if_)
-{
-    bool success = false;
-    void* stack_bottom = (void*)(((uint8_t*)USER_STACK) - PGSIZE);
+setup_stack(struct intr_frame* if_) {
+  bool success = false;
+  void* stack_bottom = (void*)(((uint8_t*)USER_STACK) - PGSIZE);
 
-    /* TODO: Map the stack on stack_bottom and claim the page immediately.
-     * TODO: If success, set the rsp accordingly.
-     * TODO: You should mark the page is stack. */
-    /* TODO: Your code goes here */
+  /* TODO: Map the stack on stack_bottom and claim the page immediately.
+   * TODO: If success, set the rsp accordingly.
+   * TODO: You should mark the page is stack. */
+  /* TODO: Your code goes here */
 
-    return success;
+  return success;
 }
 #endif /* VM */

--- a/pintos/userprog/select_test.sh
+++ b/pintos/userprog/select_test.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+
+# Usage: select_test.sh [-q|-g] [-r]
+#   -q|-g : 실행 모드 지정
+#   -r    : clean & rebuild
+if (( $# < 1 || $# > 2 )); then
+  echo "Usage: $0 [-q|-g] [-r]"
+  echo "  -q   : run tests quietly (no GDB stub)"
+  echo "  -g   : attach via GDB stub (skip build)"
+  echo "  -r   : force clean & full rebuild"
+  exit 1
+fi
+
+MODE="$1"
+if [[ "$MODE" != "-q" && "$MODE" != "-g" ]]; then
+  echo "Usage: $0 [-q|-g] [-r]"
+  exit 1
+fi
+
+# 두 번째 인자가 있으면 -r 체크
+REBUILD=0
+if (( $# == 2 )); then
+  if [[ "$2" == "-r" ]]; then
+    REBUILD=1
+  else
+    echo "Unknown option: $2"
+    echo "Usage: $0 [-q|-g] [-r]"
+    exit 1
+  fi
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../activate"
+
+CONFIG_FILE="${SCRIPT_DIR}/.test_config"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Error: .test_config 파일이 없습니다: ${CONFIG_FILE}" >&2
+  exit 1
+fi
+
+declare -A config_pre_args    
+declare -A config_post_args   
+declare -A config_prog_args   
+declare -A config_result      
+declare -A GROUP_TESTS TEST_GROUP MENU_TESTS
+declare -a ORDERED_GROUPS
+tests=()
+
+current_group=""
+
+# ---- Progress UI utilities ----
+SPINNER_PID=""
+start_spinner() {
+  # 사용법: start_spinner "메시지"
+  local msg="$1"
+  local chars='|/-\'
+  local i=0
+  # 커서 숨김
+  tput civis 2>/dev/null || true
+  # 백그라운드 스피너
+  (
+    while true; do
+      printf "\r%s %s" "$msg" "${chars:i++%${#chars}:1}"
+      sleep 0.1
+    done
+  ) &
+  SPINNER_PID=$!
+}
+
+stop_spinner() {
+  # 사용법: stop_spinner [최종메시지]
+  local final="${1:-}"
+  if [[ -n "$SPINNER_PID" ]]; then
+    kill "$SPINNER_PID" 2>/dev/null || true
+    wait "$SPINNER_PID" 2>/dev/null || true
+    SPINNER_PID=""
+  fi
+  # 현재 줄 지우고 커서 복원
+  printf "\r\033[2K"
+  tput cnorm 2>/dev/null || true
+  [[ -n "$final" ]] && echo "$final"
+}
+# 비정상 종료에도 커서 복원
+trap 'stop_spinner >/dev/null 2>&1 || true' EXIT
+
+# ---- Build helper (로그 캡처 + 경고/에러 파싱) ----
+BUILD_LOG=""
+BUILD_WARNINGS=""
+BUILD_ERRORS=""
+
+run_build() {
+  # 사용법: run_build "Build" | "Rebuild"
+  local label="$1"
+  BUILD_LOG="$(mktemp)"
+  start_spinner "${label}ing Pintos vm..."
+  {
+    make -C "${SCRIPT_DIR}" clean
+    make -C "${SCRIPT_DIR}" all -j"$(nproc)"
+  } &> "$BUILD_LOG"
+  local status=$?
+  stop_spinner
+
+  # 경고/에러 추출 (중복 제거)
+  if grep -qi "warning:" "$BUILD_LOG"; then
+    BUILD_WARNINGS="$(grep -i 'warning:' "$BUILD_LOG" | sed 's/^[[:space:]]*//' | sort -u)"
+  else
+    BUILD_WARNINGS=""
+  fi
+  if grep -qi "error:" "$BUILD_LOG"; then
+    BUILD_ERRORS="$(grep -i 'error:' "$BUILD_LOG" | sed 's/^[[:space:]]*//' | sort -u)"
+  else
+    BUILD_ERRORS=""
+  fi
+
+  return $status
+}
+
+# 빌드 실패 시 출력 유틸
+print_build_diagnostics_and_exit() {
+  echo
+  echo "====== MAKE DIAGNOSTICS ======"
+  [[ -n "$BUILD_WARNINGS" ]] && { echo "[Warnings]"; echo "$BUILD_WARNINGS"; echo; }
+  if [[ -n "$BUILD_ERRORS" ]]; then
+    echo "[Errors]"
+    echo "$BUILD_ERRORS"
+  else
+    echo "[Errors] (pattern 'error:'가 없는 실패 — 전체 로그의 마지막 80줄)"
+    tail -n 80 "$BUILD_LOG"
+  fi
+  echo "Full build log: $BUILD_LOG"
+  exit 1
+}
+
+# --- xargs와 동일한 정규화: 트림 + 공백 접기 + 양끝 작은따옴표 제거 ---
+canon() {
+  # 1) 숨은 문자 제거
+  local s=${1%$'\r'}                                   # CR
+  s="${s#$'\xEF\xBB\xBF'}"                             # BOM
+  s="${s//$'\xC2\xA0'/ }"                              # NBSP -> space
+  s="${s//$'\xE2\x80\x8B'/}"                           # ZWSP 제거
+
+  # 2) xargs처럼: IFS 공백 기준으로 토큰화 후 다시 합치기(앞뒤/연속 공백 접힘)
+  local -a a
+  IFS=$' \t\n' read -r -a a <<< "$s"
+  s="${a[*]}"                                          # 토큰들 사이에 단일 스페이스로 join
+
+  # 3) 양끝 작은따옴표가 둘다 있으면 제거 (xargs는 따옴표를 구분자로 봄)
+  if [[ ${#s} -ge 2 && ${s:0:1} == "'" && ${s: -1} == "'" ]]; then
+    s="${s:1:-1}"
+  fi
+  printf '%s' "$s"
+}
+
+# --- 파일을 한 번에 읽고(바인드 마운트 I/O 최소화) 동일 로직으로 파싱 ---
+mapfile -t _lines < "$CONFIG_FILE"
+
+# 진행표시: 전체 줄 수와 유효 라인 수는 루프에서 세자 (외부 명령 안 씀)
+total_lines=${#_lines[@]}
+parsed_lines=0
+parsed_tests=0
+parsed_groups=0
+seen_groups=()  # 그룹 수 세기용 (연관배열 안 써도 OK)
+
+# 진행 헤더 한 줄
+echo "Parsing .test_config ..."
+
+current_group=""
+for raw in "${_lines[@]}"; do
+  # 원본과 동일: '#' 이후는 주석으로 잘라냄 (따옴표 안이라도 자름)
+  line="${raw%%\#*}"
+  line="$(canon "$line")"
+  [[ -z "$line" ]] && { ((parsed_lines++)); printf "\rParsing: %d/%d" "$parsed_lines" "$total_lines"; continue; }
+
+  if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+    current_group="${BASH_REMATCH[1]}"
+    ORDERED_GROUPS+=("$current_group")
+    GROUP_TESTS["$current_group"]=""
+    # 그룹 카운트 (중복 방지 간단 처리)
+    found=0
+    for g in "${seen_groups[@]}"; do [[ "$g" == "$current_group" ]] && { found=1; break; }; done
+    (( found == 0 )) && { seen_groups+=("$current_group"); ((parsed_groups++)); }
+  else
+    IFS='|' read -r test pre_args post_args prog_args test_path <<< "$line"
+    test="$(canon "$test")"
+    pre_args="$(canon "$pre_args")"
+    post_args="$(canon "$post_args")"
+    prog_args="$(canon "$prog_args")"
+    test_path="$(canon "$test_path")"
+    [[ -z "$test" ]] && { ((parsed_lines++)); printf "\rParsing: %d/%d" "$parsed_lines" "$total_lines"; continue; }
+
+    config_pre_args["$test"]="$pre_args"
+    config_post_args["$test"]="$post_args"
+    config_prog_args["$test"]="$prog_args"
+    config_result["$test"]="$test_path"
+    tests+=("$test")
+
+    TEST_GROUP["$test"]="$current_group"
+    GROUP_TESTS["$current_group"]+="$test "
+    ((parsed_tests++))
+  fi
+
+  ((parsed_lines++))
+  # 너무 자주 찍으면 느려질 수 있어 5줄마다 한번씩 업데이트
+  if (( parsed_lines % 5 == 0 || parsed_lines == total_lines )); then
+    printf "\rParsing: %d/%d (groups: %d, tests: %d)" \
+      "$parsed_lines" "$total_lines" "$parsed_groups" "$parsed_tests"
+  else
+    printf "\rParsing: %d/%d" "$parsed_lines" "$total_lines"
+  fi
+done
+
+# 파싱 완료 라인
+printf "\r\033[2K"   # 진행줄 지우기
+echo "Parsed groups: $parsed_groups, tests: $parsed_tests"
+
+for test in "${tests[@]}"; do
+  grp="${config_result[$test]}"
+  GROUP_TESTS["$grp"]+="$test "
+done
+
+if [[ ! -d "${SCRIPT_DIR}/build" ]]; then
+  if run_build "Build"; then
+    echo "Build complete."
+    REBUILD=0
+  else
+    echo "Build failed."
+    print_build_diagnostics_and_exit
+  fi
+fi
+
+if (( REBUILD )); then
+  if run_build "Rebuild"; then
+    echo "Rebuild complete."
+  else
+    echo "Rebuild failed."
+    print_build_diagnostics_and_exit
+  fi
+fi
+
+
+STATE_FILE="${SCRIPT_DIR}/.test_status"
+declare -A status_map
+
+if [[ -f "$STATE_FILE" ]]; then
+  while read -r test stat; do
+    status_map["$test"]="$stat"
+  done < "$STATE_FILE"
+fi
+
+echo "=== Available Pintos Tests ==="
+index=1
+for grp in "${ORDERED_GROUPS[@]}"; do
+  tests_in_grp="${GROUP_TESTS[$grp]}"
+  [[ -z "$tests_in_grp" ]] && continue
+
+  echo
+  echo "▶ ${grp^} tests:"
+  for test in $tests_in_grp; do
+    stat="${status_map[$test]:-untested}"
+    case "$stat" in
+      PASS) color="\e[32m" ;;
+      FAIL) color="\e[31m" ;;
+      *)    color="\e[0m"  ;;
+    esac
+    printf "  ${color}%2d) %s\e[0m\n" "$index" "$test"
+    MENU_TESTS[$index]="$test"
+    ((index++))
+  done
+done
+
+read -p "Enter test numbers (e.g. '1 3 5' or '2-4'): " input
+tokens=()
+for tok in ${input//,/ }; do
+  if [[ "$tok" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+    for ((n=${BASH_REMATCH[1]}; n<=${BASH_REMATCH[2]}; n++)); do
+      tokens+=("$n")
+    done
+  else
+    tokens+=("$tok")
+  fi
+done
+
+declare -A seen=()
+sel_tests=()
+for n in "${tokens[@]}"; do
+  if [[ "$n" =~ ^[0-9]+$ ]] && (( n>=1 && n<=${#tests[@]} )); then
+    idx=$((n-1))
+    if [[ -z "${seen[$n]}" ]]; then
+      sel_tests+=("${MENU_TESTS[$n]}")
+      seen[$n]=1
+    fi
+  else
+    echo "Invalid test number: $n" >&2
+    exit 1
+  fi
+done
+
+echo "Selected tests: ${sel_tests[*]}"
+
+passed=()
+failed=()
+{
+  cd "${SCRIPT_DIR}/build" || exit 1
+
+  count=0
+  total=${#sel_tests[@]}
+  for test in "${sel_tests[@]}"; do
+    echo
+    pre_args="${config_pre_args[$test]}"
+    post_args="${config_post_args[$test]}"
+    prog_args="${config_prog_args[$test]}"
+    dir="${config_result[$test]}"
+    res="${dir}/${test}.result"
+
+    mkdir -p ${dir}
+    
+    if [[ "$MODE" == "-q" ]]; then
+      cmd="pintos ${pre_args} -- ${post_args} '${prog_args}'"
+      echo "Running ${test} in batch mode... "
+      echo "\$ ${cmd}"
+      echo
+      if make -s ${res} \
+            ARGS="${pre_args} -- ${post_args} '${prog_args}'"; then
+        if grep -q '^PASS' ${res}; then
+          echo "PASS"; passed+=("$test")
+        else
+          echo "FAIL"; failed+=("$test")
+        fi
+      else
+        echo "FAIL"; failed+=("$test")
+      fi
+    else
+      echo -e "=== Debugging \e[33m${test}\e[0m ($(( count + 1 ))/${total}) ==="
+      echo -e "\e[33mVSCode의 \"Pintos Debug\" 디버그를 시작하세요.\e[0m"
+      echo " * QEMU 창이 뜨고, gdb stub은 localhost:1234 에서 대기합니다."
+      echo " * 내부 출력은 터미널에 보이면서 '${dir}/${test}.output'에도 저장됩니다."
+      echo
+
+      cmd="pintos --gdb ${pre_args} -- ${post_args} '${prog_args}'"
+      echo "\$ ${cmd}"
+      eval "${cmd}" 2>&1 | tee "${dir}/${test}.output"
+
+      repo_root="${SCRIPT_DIR}/.."
+      ck="${repo_root}/${dir}/${test}.ck"
+      if [[ -f "$ck" ]]; then
+        perl -I "${repo_root}" \
+             "$ck" "${dir}/${test}" "${dir}/${test}.result"
+        if grep -q '^PASS' "${dir}/${test}.result"; then
+          echo "=> PASS"; passed+=("$test")
+        else
+          echo "=> FAIL"; failed+=("$test")
+        fi
+      else
+        echo "=> No .ck script, skipping result."; failed+=("$test")
+      fi
+      echo "=== ${test} session end ==="
+    fi
+
+    ((count++))
+    echo -e "\e[33mtest ${count}/${total} finish\e[0m"
+  done
+}
+
+echo
+echo "=== Test Summary ==="
+echo "Passed: ${#passed[@]}"
+for t in "${passed[@]}"; do echo "  - $t"; done
+echo "Failed: ${#failed[@]}"
+for t in "${failed[@]}"; do echo "  - $t"; done
+
+for t in "${passed[@]}"; do
+  status_map["$t"]="PASS"
+done
+for t in "${failed[@]}"; do
+  status_map["$t"]="FAIL"
+done
+
+> "$STATE_FILE"
+for test in "${!status_map[@]}"; do
+  echo "$test ${status_map[$test]}"
+done >| "$STATE_FILE"

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -39,8 +39,7 @@ void syscall_init (void) {
 /* The main system call interface */
 void syscall_handler (struct intr_frame *f UNUSED) {
 	// TODO: Your implementation goes here.
-	int syscall_num = *(int *)f->es;
-
+	// int syscall_num = *(int *)f->es;
 
 	printf ("system call!\n");
 	thread_exit ();


### PR DESCRIPTION
## 요약
사용자 프로그램에 명령줄 인자를 전달하는 기능을 구현합니다.
`process_exec()`에서 명령줄을 파싱하고, load() 함수에서 x86-64 system 규약에 맞게 사용자 스택을 설정하여 main 함수의 argc와 argv로 인자를 전달할 수 있도록 수정했습니다.

## 주요 변경 사항
1.`process_exec()` - 명령줄 파싱

- `process_exec` 함수는 이제 전체 명령줄 문자열(예: "args-none")을 인자로 받습니다.
- `strtok_r` 함수를 사용하여 공백을 기준으로 문자열을 토큰으로 분리하고, 이를 `argv` 배열에 저장합니다.
- 완성된 `argv` 배열을 `load()` 함수로 전달하여 스택을 구성하도록 합니다.

2.`load()` - 사용자 스택 설정
`load()` 함수는 전달받은 `argv`를 사용하여 사용자 스택을 설정하는 핵심 로직을 포함합니다. 스택은 높은 주소에서 낮은 주소 순서로 다음과 같이 구성됩니다.

1. 인자 문자열 저장: argv 배열에 있는 각 인자 문자열의 내용("args-none" 등)을 스택에 push합니다.
2. 워드 정렬 (Word Align): 스택 포인터를 8의 배수로 맞추기 위해 패딩(padding)을 추가합니다.
3. 인자 주소 저장: 스택에 저장된 인자 문자열들의 주소를 argv 배열의 역순(argv[n-1]부터 argv[0] 순서)으로 push합니다. argv의 끝을 알리는 NULL 포인터도 함께 저장합니다.
4. main 함수 인자 설정:◦RDI 레지스터에 인자의 개수(argc)를 설정합니다.◦RSI 레지스터에 스택에 저장된 인자 주소 배열의 시작 주소(argv)를 설정합니다.
5. 가짜 반환 주소(Fake Return Address): main 함수가 종료된 후 돌아갈 주소로, 실제로는 사용되지 않지만 ABI 규약을 지키기 위해 0을 push합니다.
6. 스택 포인터(rsp) 최종 설정: 위 모든 과정이 끝난 후의 최종 스택 포인터 값을 intr_frame의 rsp에 저장합니다.

## 결과
위 변경 사항을 통해 `args-none` 프로그램이 정상적으로 실행되어 `syscall_handler` 함수에서 "system call!" 출력이 나오는 것을 확인하였습니다.

## 후속 작업
이 변경 사항을 바탕으로 syscall.c에 시스템 콜 인터페이스를 구현하여, 사용자 프로그램이 커널의 기능을 사용할 수 있도록 확장할 계획입니다. (exit, write 등)