### PR TITLE
feat(vm): 페이지 폴트 핸들러 구현 및 핼퍼 함수 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -6,7 +6,8 @@
 #include "threads/mmu.h"
 #include "vm/inspect.h"
 
-static struct list frame_table;  // 구조체 추가
+static struct list frame_table; // 구조체 추가
+static bool is_valid_stack_access(void* addr, const uintptr_t rsp);
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -19,14 +20,13 @@ void vm_init(void) {
   register_inspect_intr();
   /* DO NOT MODIFY UPPER LINES. */
   /* TODO: Your code goes here. */
-  list_init(&frame_table);  // 구조체 초기화
+  list_init(&frame_table); // 구조체 초기화
 }
 
 /* Get the type of the page. This function is useful if you want to know the
  * type of the page after it will be initialized.
  * This function is fully implemented now. */
-enum vm_type
-page_get_type(struct page *page) {
+enum vm_type page_get_type(struct page *page) {
   int ty = VM_TYPE(page->operations->type);
   switch (ty) {
     case VM_UNINIT:
@@ -61,7 +61,7 @@ static struct frame *vm_evict_frame(void);
  */
 bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
                                     vm_initializer *init, void *aux) {
-  ASSERT(VM_TYPE(type) != VM_UNINIT)  // 타입이 UNINIT 자체로 들어오면 안 됨
+  ASSERT(VM_TYPE(type) != VM_UNINIT) // 타입이 UNINIT 자체로 들어오면 안 됨
 
   struct supplemental_page_table *spt = &thread_current()->spt;
 
@@ -69,18 +69,17 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   if (spt_find_page(spt, upage) == NULL) {
     /* 2. 새로운 page 구조체 동적 할당 */
     struct page *page = malloc(sizeof(struct page));
-    if (!page)
-      goto err;  // 메모리 부족 → 실패 처리
+    if (!page) goto err; // 메모리 부족 → 실패 처리
 
     /* 3. 타입에 따라 실제 초기화 함수 선택 */
     typedef bool (*initializer_by_type)(struct page *, enum vm_type, void *);
     initializer_by_type initializer = NULL;
 
     switch (VM_TYPE(type)) {
-      case VM_ANON:  // 익명 페이지
+      case VM_ANON: // 익명 페이지
         initializer = anon_initializer;
         break;
-      case VM_FILE:  // 파일 매핑 페이지
+      case VM_FILE: // 파일 매핑 페이지
         initializer = file_backed_initializer;
         break;
     }
@@ -98,7 +97,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   }
 
 err:
-  return false;  // 이미 존재하거나 메모리 부족 → 실패
+  return false; // 이미 존재하거나 메모리 부족 → 실패
 }
 
 /*
@@ -110,8 +109,7 @@ err:
  *   같은 va를 가진 hash_elem을 찾는다.
  * - 찾으면 해당 struct page를 반환, 없으면 NULL 반환.
  */
-struct page *
-spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
   /* 1. 비교용 임시 page 구조체 생성 */
   struct page page;
 
@@ -154,8 +152,7 @@ void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
 }
 
 /* Get the struct frame, that will be evicted. */
-static struct frame *
-vm_get_victim(void) {
+static struct frame *vm_get_victim(void) {
   struct frame *victim = NULL;
   /* TODO: The policy for eviction is up to you. */
 
@@ -164,8 +161,7 @@ vm_get_victim(void) {
 
 /* Evict one page and return the corresponding frame.
  * Return NULL on error.*/
-static struct frame *
-vm_evict_frame(void) {
+static struct frame *vm_evict_frame(void) {
   struct frame *victim UNUSED = vm_get_victim();
   /* TODO: swap out the victim and return the evicted frame. */
 
@@ -180,8 +176,7 @@ vm_evict_frame(void) {
  *   프레임을 확보한다.
  * - 최종적으로 유효한 프레임을 반환한다.
  */
-static struct frame *
-vm_get_frame(void) {
+static struct frame *vm_get_frame(void) {
   struct frame *frame = NULL;
 
   /* 1. 프레임 구조체 자체를 동적 할당한다.
@@ -198,8 +193,7 @@ vm_get_frame(void) {
   /* 3. 물리 페이지를 얻지 못했을 경우 → 프레임이 가득 찼다는 뜻
    *    - 이때는 교체 정책(eviction policy)을 통해
    *      victim frame을 골라 swap out 한 뒤 프레임을 회수해야 한다. */
-  if (frame->kva == NULL)
-    frame = vm_evict_frame();
+  if (frame->kva == NULL) frame = vm_evict_frame();
   else
     /* 4. 정상적으로 프레임을 확보했다면
      *    frame_table (글로벌 프레임 리스트)에 추가한다.
@@ -218,24 +212,53 @@ vm_get_frame(void) {
 }
 
 /* Growing the stack. */
-static void
-vm_stack_growth(void *addr UNUSED) {
+static void vm_stack_growth(void *addr UNUSED) {
 }
 
 /* Handle the fault on write_protected page */
-static bool
-vm_handle_wp(struct page *page UNUSED) {
+static bool vm_handle_wp(struct page *page UNUSED) {
 }
 
 /* Return true on success */
-bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
-                         bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-  struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
-  struct page *page = NULL;
-  /* TODO: Validate the fault */
-  /* TODO: Your code goes here */
+bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write, bool not_present) {
+  struct supplemental_page_table* spt = &thread_current()->spt;
+  struct page* page = NULL;
+  // ============================================
+  // Step 1: 주소 정렬 및 기본 검증
+  // ============================================
 
-  return vm_do_claim_page(page);
+  // 1: addr을 페이지 단위로 정렬
+  // 페이지 시작 주소로 정렬
+  void *page_addr = pg_round_down(addr);
+
+  // 2: User 영역인지 확인 : 보안
+  if (!is_user_vaddr(page_addr)) {
+    return false;
+  }
+
+  // ============================================
+  // Step 2: SPT에서 페이지 찾기
+  // ============================================
+
+  page = spt_find_page(spt, page_addr);
+
+  if (page != NULL) {
+    return vm_do_claim_page(page);
+  }
+
+  // ============================================
+  // Step 3: Stack Growth 확인
+  // ============================================
+  // rsp 근처인지, stack 영역인지, 1MB 제한을 넘었는지 (1 << 20 = 1MB)
+  if (is_valid_stack_access(page_addr, f->rsp)) {
+    vm_stack_growth(page_addr);
+    return true;
+  }
+
+  // ============================================
+  // Step 4: Invalid Access 처리
+  // ============================================
+  return false;
 }
 
 /* Free the page.
@@ -259,8 +282,7 @@ bool vm_claim_page(void *va UNUSED) {
    * 만약 존재하지 않으면 (즉, 아직 관리되지 않는 주소라면) 실패 처리. */
   page = spt_find_page(&thread_current()->spt, va);
 
-  if (page == NULL)
-    return false;
+  if (page == NULL) return false;
 
   /* 페이지를 실제 물리 프레임에 할당하고 매핑하는 작업 진행 */
   return vm_do_claim_page(page);
@@ -288,8 +310,7 @@ static bool vm_do_claim_page(struct page *page) {
    *      가상주소와 물리주소를 매핑한다.
    *    - writable 플래그에 따라 쓰기 가능 여부를 설정한다.
    *    - 실패하면 false 반환. */
-  if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable))
-    return false;
+  if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)) return false;
 
   /* 4. 페이지 타입에 맞게 실제 데이터를 메모리에 적재 (swap_in 호출)
    *    - 예: Lazy load의 경우 파일에서 읽어오기
@@ -300,7 +321,7 @@ static bool vm_do_claim_page(struct page *page) {
 
 /* Initialize new supplemental page table */
 void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
-  hash_init(spt, page_hash, page_less, NULL);  // spt 초기화
+  hash_init(spt, page_hash, page_less, NULL); // spt 초기화
 }
 
 /* Copy supplemental page table from src to dst */
@@ -322,8 +343,7 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
  * - hash_bytes(): 주어진 메모리 블록을 바이트 단위로 해싱하는 Pintos 유틸 함수.
  * - 결국 동일한 가상 주소를 가진 page 는 동일한 해시 값으로 매핑됨.
  */
-uint64_t
-page_hash(const struct hash_elem *e, void *aux UNUSED) {
+uint64_t page_hash(const struct hash_elem *e, void *aux UNUSED) {
   struct page *page = hash_entry(e, struct page, hash_elem);
   return hash_bytes(&page->va, sizeof page->va);
 }
@@ -340,4 +360,17 @@ bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux U
   struct page *page_b = hash_entry(b, struct page, hash_elem);
 
   return page_a->va < page_b->va;
+}
+
+static bool is_valid_stack_access(void* addr, const uintptr_t rsp) {
+  uintptr_t fault_addr = (uintptr_t)addr;
+
+  // stack 영역 확인
+  if (fault_addr >= USER_STACK) return false;
+  // rsp 근처 확인
+  if (fault_addr < rsp - 32) return false;
+  // 1MB 제한 확인
+  if (USER_STACK - fault_addr > (1 << 20)) return false;
+
+  return true;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -6,8 +6,8 @@
 #include "threads/mmu.h"
 #include "vm/inspect.h"
 
-static struct list frame_table; // 구조체 추가
-static bool is_valid_stack_access(void* addr, const uintptr_t rsp);
+static struct list frame_table;  // 구조체 추가
+static bool is_valid_stack_access(void *addr, const uintptr_t rsp);
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -20,7 +20,7 @@ void vm_init(void) {
   register_inspect_intr();
   /* DO NOT MODIFY UPPER LINES. */
   /* TODO: Your code goes here. */
-  list_init(&frame_table); // 구조체 초기화
+  list_init(&frame_table);  // 구조체 초기화
 }
 
 /* Get the type of the page. This function is useful if you want to know the
@@ -61,7 +61,7 @@ static struct frame *vm_evict_frame(void);
  */
 bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
                                     vm_initializer *init, void *aux) {
-  ASSERT(VM_TYPE(type) != VM_UNINIT) // 타입이 UNINIT 자체로 들어오면 안 됨
+  ASSERT(VM_TYPE(type) != VM_UNINIT)  // 타입이 UNINIT 자체로 들어오면 안 됨
 
   struct supplemental_page_table *spt = &thread_current()->spt;
 
@@ -69,17 +69,17 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   if (spt_find_page(spt, upage) == NULL) {
     /* 2. 새로운 page 구조체 동적 할당 */
     struct page *page = malloc(sizeof(struct page));
-    if (!page) goto err; // 메모리 부족 → 실패 처리
+    if (!page) goto err;  // 메모리 부족 → 실패 처리
 
     /* 3. 타입에 따라 실제 초기화 함수 선택 */
     typedef bool (*initializer_by_type)(struct page *, enum vm_type, void *);
     initializer_by_type initializer = NULL;
 
     switch (VM_TYPE(type)) {
-      case VM_ANON: // 익명 페이지
+      case VM_ANON:  // 익명 페이지
         initializer = anon_initializer;
         break;
-      case VM_FILE: // 파일 매핑 페이지
+      case VM_FILE:  // 파일 매핑 페이지
         initializer = file_backed_initializer;
         break;
     }
@@ -97,7 +97,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   }
 
 err:
-  return false; // 이미 존재하거나 메모리 부족 → 실패
+  return false;  // 이미 존재하거나 메모리 부족 → 실패
 }
 
 /*
@@ -193,7 +193,8 @@ static struct frame *vm_get_frame(void) {
   /* 3. 물리 페이지를 얻지 못했을 경우 → 프레임이 가득 찼다는 뜻
    *    - 이때는 교체 정책(eviction policy)을 통해
    *      victim frame을 골라 swap out 한 뒤 프레임을 회수해야 한다. */
-  if (frame->kva == NULL) frame = vm_evict_frame();
+  if (frame->kva == NULL)
+    frame = vm_evict_frame();
   else
     /* 4. 정상적으로 프레임을 확보했다면
      *    frame_table (글로벌 프레임 리스트)에 추가한다.
@@ -220,9 +221,9 @@ static bool vm_handle_wp(struct page *page UNUSED) {
 }
 
 /* Return true on success */
-bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write, bool not_present) {
-  struct supplemental_page_table* spt = &thread_current()->spt;
-  struct page* page = NULL;
+bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user, bool write, bool not_present) {
+  struct supplemental_page_table *spt = &thread_current()->spt;
+  struct page *page = NULL;
   // ============================================
   // Step 1: 주소 정렬 및 기본 검증
   // ============================================
@@ -321,7 +322,7 @@ static bool vm_do_claim_page(struct page *page) {
 
 /* Initialize new supplemental page table */
 void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
-  hash_init(spt, page_hash, page_less, NULL); // spt 초기화
+  hash_init(spt, page_hash, page_less, NULL);  // spt 초기화
 }
 
 /* Copy supplemental page table from src to dst */
@@ -362,7 +363,7 @@ bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux U
   return page_a->va < page_b->va;
 }
 
-static bool is_valid_stack_access(void* addr, const uintptr_t rsp) {
+static bool is_valid_stack_access(void *addr, const uintptr_t rsp) {
   uintptr_t fault_addr = (uintptr_t)addr;
 
   // stack 영역 확인


### PR DESCRIPTION
페이지 폴트가 발생했을 때, 해당 접근이 유효한 스택 확장 요구인지 판단하고 새로운 스택 페이지를 할당하는 로직을 추가했습니다.

- `vm_try_handle_fault` 함수 내에서 SPT에 페이지가 없을 경우, 스택 확장 가능성을 검사합니다.
- `is_valid_stack_access` 헬퍼 함수를 구현하여, 폴트 주소가 현재 스택 포인터(RSP) 근처이고, 최대 스택 크기(1MB)를 넘지 않는 유효한 접근인지 확인합니다.
- 유효한 스택 접근으로 판단되면 `vm_stack_growth`를 호출하여 새 페이지를 할당합니다.