### PR TITLE
anon.c 구현하기 전에 project2 테스트들 pass시키기 위한 사전 작업

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,11 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+            
+          prompt: |
+            사용자의 요청을 수행하되, 반드시 한국어로 답변해주세요.
+            코드 리뷰, 설명, 제안 등 모든 응답은 한국어로 작성해야 합니다.
+            기술 용어는 영어 그대로 사용해도 되지만, 문장과 설명은 한국어로 작성하세요.
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,8 +49,8 @@
   /* 줄바꿈 설정 */
   "files.eol": "\n", // LF 사용
   /* C/C++ 특화 설정 */
-  "C_Cpp.clang_format_fallbackStyle": "Google", // 기본 스타일을 Google로 설정
-  "C_Cpp.clang_format_sortIncludes": true, // #include문 자동 정렬 활성화
+  "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: Google, IndentWidth: 2, TabWidth: 2, UseTab: Never, ColumnLimit: 0 }",
+  "C_Cpp.clang_format_sortIncludes": true,
   /* 기타 편의 설정 */
   "editor.minimap.enabled": false, // 미니맵 비활성화
   "editor.renderWhitespace": "boundary", // 공백 문자 시각화

--- a/pintos/include/threads/init.h
+++ b/pintos/include/threads/init.h
@@ -1,6 +1,8 @@
 #ifndef THREADS_INIT_H
 #define THREADS_INIT_H
 
+// test
+
 #include <debug.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -15,6 +17,6 @@ extern uint64_t *base_pml4;
 /* -q: Power off when kernel tasks complete? */
 extern bool power_off_when_done;
 
-void power_off (void) NO_RETURN;
+void power_off(void) NO_RETURN;
 
 #endif /* threads/init.h */

--- a/pintos/include/threads/init.h
+++ b/pintos/include/threads/init.h
@@ -1,8 +1,6 @@
 #ifndef THREADS_INIT_H
 #define THREADS_INIT_H
 
-// test
-
 #include <debug.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/pintos/include/vm/anon.h
+++ b/pintos/include/vm/anon.h
@@ -5,9 +5,10 @@ struct page;
 enum vm_type;
 
 struct anon_page {
+  uint8_t swap_index;
 };
 
-void vm_anon_init (void);
-bool anon_initializer (struct page *page, enum vm_type type, void *kva);
+void vm_anon_init(void);
+bool anon_initializer(struct page *page, enum vm_type type, void *kva);
 
 #endif

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -65,9 +65,9 @@ struct page {
 
 /* The representation of "frame" */
 struct frame {
-  void *kva;
-  struct page *page;
-  struct list_elem frame_elem;
+  void *kva;                    // 커널 가상 주소 (실제 물리 메모리를 가리킴)
+  struct page *page;            // 이 프레임을 사용하는 페이지
+  struct list_elem frame_elem;  // frame_table에 들어갈 때 사용
 };
 
 /* The function table for page operations.

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -66,6 +66,7 @@ struct page {
 struct frame {
   void *kva;
   struct page *page;
+  struct list_elem frame_elem;
 };
 
 /* The function table for page operations.

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -127,4 +127,5 @@ enum vm_type page_get_type(struct page *page);
 
 uint64_t page_hash(const struct hash_elem *e, void *aux);  // 선언
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
+void hash_action_destroy(struct hash_elem *hash_elem_, void *aux);
 #endif /* VM_VM_H */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -60,6 +60,7 @@ struct page {
 #endif
   };
   struct hash_elem hash_elem;  // hash_elem 추가
+  bool writable                // bool 변수 추기
 };
 
 /* The representation of "frame" */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -114,4 +114,6 @@ void vm_dealloc_page(struct page *page);
 bool vm_claim_page(void *va);
 enum vm_type page_get_type(struct page *page);
 
+uint64_t page_hash(const struct hash_elem *e, void *aux);  // 선언
+bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
 #endif /* VM_VM_H */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -94,6 +94,15 @@ struct supplemental_page_table {
   struct hash spt_hash;  // 해시 구조체 추가
 };
 
+/* process.c load_segment의 vm_alloc_page_with_initializer의 네 번째 인자인
+ * lazy_load_segment 함수에 전달될 인자 aux구조체 */
+struct file_loader {
+  size_t page_read_bytes;
+  size_t page_zero_bytes;
+  off_t ofs;
+  struct file *file;
+};
+
 #include "threads/thread.h"
 void supplemental_page_table_init(struct supplemental_page_table *spt);
 bool supplemental_page_table_copy(struct supplemental_page_table *dst,

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -60,7 +60,7 @@ struct page {
 #endif
   };
   struct hash_elem hash_elem;  // hash_elem 추가
-  bool writable                // bool 변수 추기
+  bool writable;               // bool 변수 추기
 };
 
 /* The representation of "frame" */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -1,32 +1,34 @@
 #ifndef VM_VM_H
 #define VM_VM_H
+#include <hash.h>  // hash include
 #include <stdbool.h>
+
 #include "threads/palloc.h"
 
 enum vm_type {
-	/* page not initialized */
-	VM_UNINIT = 0,
-	/* page not related to the file, aka anonymous page */
-	VM_ANON = 1,
-	/* page that realated to the file */
-	VM_FILE = 2,
-	/* page that hold the page cache, for project 4 */
-	VM_PAGE_CACHE = 3,
+  /* page not initialized */
+  VM_UNINIT = 0,
+  /* page not related to the file, aka anonymous page */
+  VM_ANON = 1,
+  /* page that realated to the file */
+  VM_FILE = 2,
+  /* page that hold the page cache, for project 4 */
+  VM_PAGE_CACHE = 3,
 
-	/* Bit flags to store state */
+  /* Bit flags to store state */
 
-	/* Auxillary bit flag marker for store information. You can add more
-	 * markers, until the value is fit in the int. */
-	VM_MARKER_0 = (1 << 3),
-	VM_MARKER_1 = (1 << 4),
+  /* Auxillary bit flag marker for store information. You can add more
+   * markers, until the value is fit in the int. */
+  VM_MARKER_0 = (1 << 3),
+  VM_MARKER_1 = (1 << 4),
 
-	/* DO NOT EXCEED THIS VALUE. */
-	VM_MARKER_END = (1 << 31),
+  /* DO NOT EXCEED THIS VALUE. */
+  VM_MARKER_END = (1 << 31),
 };
 
-#include "vm/uninit.h"
 #include "vm/anon.h"
 #include "vm/file.h"
+#include "vm/uninit.h"
 #ifdef EFILESYS
 #include "filesys/page_cache.h"
 #endif
@@ -41,28 +43,29 @@ struct thread;
  * uninit_page, file_page, anon_page, and page cache (project4).
  * DO NOT REMOVE/MODIFY PREDEFINED MEMBER OF THIS STRUCTURE. */
 struct page {
-	const struct page_operations *operations;
-	void *va;              /* Address in terms of user space */
-	struct frame *frame;   /* Back reference for frame */
+  const struct page_operations *operations;
+  void *va;            /* Address in terms of user space */
+  struct frame *frame; /* Back reference for frame */
 
-	/* Your implementation */
+  /* Your implementation */
 
-	/* Per-type data are binded into the union.
-	 * Each function automatically detects the current union */
-	union {
-		struct uninit_page uninit;
-		struct anon_page anon;
-		struct file_page file;
+  /* Per-type data are binded into the union.
+   * Each function automatically detects the current union */
+  union {
+    struct uninit_page uninit;
+    struct anon_page anon;
+    struct file_page file;
 #ifdef EFILESYS
-		struct page_cache page_cache;
+    struct page_cache page_cache;
 #endif
-	};
+  };
+  struct hash_elem hash_elem;  // hash_elem 추가
 };
 
 /* The representation of "frame" */
 struct frame {
-	void *kva;
-	struct page *page;
+  void *kva;
+  struct page *page;
 };
 
 /* The function table for page operations.
@@ -70,43 +73,45 @@ struct frame {
  * Put the table of "method" into the struct's member, and
  * call it whenever you needed. */
 struct page_operations {
-	bool (*swap_in) (struct page *, void *);
-	bool (*swap_out) (struct page *);
-	void (*destroy) (struct page *);
-	enum vm_type type;
+  bool (*swap_in)(struct page *, void *);
+  bool (*swap_out)(struct page *);
+  void (*destroy)(struct page *);
+  enum vm_type type;
 };
 
-#define swap_in(page, v) (page)->operations->swap_in ((page), v)
-#define swap_out(page) (page)->operations->swap_out (page)
+#define swap_in(page, v) (page)->operations->swap_in((page), v)
+#define swap_out(page) (page)->operations->swap_out(page)
 #define destroy(page) \
-	if ((page)->operations->destroy) (page)->operations->destroy (page)
+  if ((page)->operations->destroy) (page)->operations->destroy(page)
 
 /* Representation of current process's memory space.
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
+
 struct supplemental_page_table {
+  struct hash spt_hash;  // 해시 구조체 추가
 };
 
 #include "threads/thread.h"
-void supplemental_page_table_init (struct supplemental_page_table *spt);
-bool supplemental_page_table_copy (struct supplemental_page_table *dst,
-		struct supplemental_page_table *src);
-void supplemental_page_table_kill (struct supplemental_page_table *spt);
-struct page *spt_find_page (struct supplemental_page_table *spt,
-		void *va);
-bool spt_insert_page (struct supplemental_page_table *spt, struct page *page);
-void spt_remove_page (struct supplemental_page_table *spt, struct page *page);
+void supplemental_page_table_init(struct supplemental_page_table *spt);
+bool supplemental_page_table_copy(struct supplemental_page_table *dst,
+                                  struct supplemental_page_table *src);
+void supplemental_page_table_kill(struct supplemental_page_table *spt);
+struct page *spt_find_page(struct supplemental_page_table *spt,
+                           void *va);
+bool spt_insert_page(struct supplemental_page_table *spt, struct page *page);
+void spt_remove_page(struct supplemental_page_table *spt, struct page *page);
 
-void vm_init (void);
-bool vm_try_handle_fault (struct intr_frame *f, void *addr, bool user,
-		bool write, bool not_present);
+void vm_init(void);
+bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user,
+                         bool write, bool not_present);
 
 #define vm_alloc_page(type, upage, writable) \
-	vm_alloc_page_with_initializer ((type), (upage), (writable), NULL, NULL)
-bool vm_alloc_page_with_initializer (enum vm_type type, void *upage,
-		bool writable, vm_initializer *init, void *aux);
-void vm_dealloc_page (struct page *page);
-bool vm_claim_page (void *va);
-enum vm_type page_get_type (struct page *page);
+  vm_alloc_page_with_initializer((type), (upage), (writable), NULL, NULL)
+bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
+                                    bool writable, vm_initializer *init, void *aux);
+void vm_dealloc_page(struct page *page);
+bool vm_claim_page(void *va);
+enum vm_type page_get_type(struct page *page);
 
-#endif  /* VM_VM_H */
+#endif /* VM_VM_H */

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -1,52 +1,65 @@
 /* anon.c: Implementation of page for non-disk image (a.k.a. anonymous page). */
 
-#include "vm/vm.h"
 #include "devices/disk.h"
+#include "threads/vaddr.h"
+#include "vm/vm.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
-static bool anon_swap_in (struct page *page, void *kva);
-static bool anon_swap_out (struct page *page);
-static void anon_destroy (struct page *page);
+static bool anon_swap_in(struct page *page, void *kva);
+static bool anon_swap_out(struct page *page);
+static void anon_destroy(struct page *page);
 
 /* DO NOT MODIFY this struct */
 static const struct page_operations anon_ops = {
-	.swap_in = anon_swap_in,
-	.swap_out = anon_swap_out,
-	.destroy = anon_destroy,
-	.type = VM_ANON,
+    .swap_in = anon_swap_in,
+    .swap_out = anon_swap_out,
+    .destroy = anon_destroy,
+    .type = VM_ANON,
 };
 
+/* 디스크에서 사용 가능한 swap slot과 사용 불가능한 swap slot을
+  관리하는 자료구조
+  bitmap 구조체 사용
+    - bit를 저장하는 연속된 메모리 공간 위의 배열 객체
+    - 각각의 비트가 swap_slot과 매칭, 1인 경우 swap out되어
+    디스크의 swap 공간에 임시 저장되었다는 뜻 */
+struct bitmap *swap_table;
+
+/* PGSZIE == 1<<12byte (4kb) / DISK_SECTOR_SIZE == 512byte
+  SECTOR_PER_PAGE == 8 */
+const size_t SECTOR_PER_PAGE = PGSIZE / DISK_SECTOR_SIZE;
+
 /* Initialize the data for anonymous pages */
-void
-vm_anon_init (void) {
-	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+void vm_anon_init(void) {
+  /* TODO: Set up the swap_disk. */
+  swap_disk = disk_get(1, 1);
+  size_t swap_size = disk_size(swap_disk) / SECTOR_PER_PAGE;
+  swap_table = bitmap_create(swap_size);
 }
 
 /* Initialize the file mapping */
-bool
-anon_initializer (struct page *page, enum vm_type type, void *kva) {
-	/* Set up the handler */
-	page->operations = &anon_ops;
+bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
+  /* Set up the handler */
+  page->operations = &anon_ops;
 
-	struct anon_page *anon_page = &page->anon;
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Swap in the page by read contents from the swap disk. */
 static bool
-anon_swap_in (struct page *page, void *kva) {
-	struct anon_page *anon_page = &page->anon;
+anon_swap_in(struct page *page, void *kva) {
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
 static bool
-anon_swap_out (struct page *page) {
-	struct anon_page *anon_page = &page->anon;
+anon_swap_out(struct page *page) {
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void
-anon_destroy (struct page *page) {
-	struct anon_page *anon_page = &page->anon;
+anon_destroy(struct page *page) {
+  struct anon_page *anon_page = &page->anon;
 }

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -40,10 +40,20 @@ void vm_anon_init(void) {
 
 /* Initialize the file mapping */
 bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
+  /* page struct 안의 union영역은 현재 uninit page
+    ANON page 0초기화 -> union영역 0초기화됨*/
+  struct uninit_page *uninit = &page->uninit;
+  memset(uninit, 0, sizeof(struct uninit_page));
+
   /* Set up the handler */
+  /* 해당 페이지는 이제 ANON*/
   page->operations = &anon_ops;
 
+  /* 해당 페이지는 아직 물리 메모리 위에 있음 -> swap_index값 -1로 설정*/
   struct anon_page *anon_page = &page->anon;
+  anon_page->swap_index = -1;
+
+  return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -108,12 +108,25 @@ vm_evict_frame(void) {
  * and return it. This always return valid address. That is, if the user pool
  * memory is full, this function evicts the frame to get the available memory
  * space.*/
+
+// palloc_get_page 함수를 호출하여 사용자 풀에서 새로운 physical page(frame)를 가져옴
+// 사용 가능한 page가 없다면 swap out을 수행
 static struct frame *
 vm_get_frame(void) {
   struct frame *frame = NULL;
   /* TODO: Fill this function. */
-
+  struct frame *frame = (struct frame *)malloc(sizeof(struct frame));
   ASSERT(frame != NULL);
+
+  frame->kva = palloc_get_page(PAL_USER | PAL_ZERO);
+
+  if (frame->kva == NULL)
+    frame = vm_evict_frame();
+  else
+    list_push_back(&frame_table, &frame->frame_elem);
+
+  frame->page = NULL;
+
   ASSERT(frame->page == NULL);
   return frame;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -41,72 +41,119 @@ static struct frame *vm_get_victim(void);
 static bool vm_do_claim_page(struct page *page);
 static struct frame *vm_evict_frame(void);
 
-/* Create the pending page object with initializer. If you want to create a
- * page, do not create it directly and make it through this function or
- * `vm_alloc_page`. */
-
-// upage가 이미 사용 중인지 확인한다.
-// 페이지를 생성한다.
-// type에 따라 초기화 함수를 가져온다.
-//"uninit" 타입의 페이지로 초기화한다.
-// 필드 수정은 uninit_new를 호출한 이후에 해야 한다.
-// 생성한 페이지를 SPT에 추가한다.
+/*
+ * vm_alloc_page_with_initializer()
+ *
+ * 새로운 가상 페이지를 생성하고, 초기화 함수를 연결한 뒤
+ * Supplemental Page Table(SPT)에 삽입하는 함수.
+ *
+ * 주요 동작:
+ *  1. 요청된 가상 주소(upage)가 이미 SPT에 존재하는지 확인
+ *  2. 존재하지 않으면 struct page 동적 할당
+ *  3. 페이지 타입(VM_ANON, VM_FILE)에 따라 적절한 초기화 함수 선택
+ *  4. uninit_new()를 호출하여 "미할당(uninitialized)" 페이지로 생성
+ *     - 실제 물리 프레임은 아직 매핑하지 않음
+ *     - 초기화 함수 포인터와 aux를 보관하여 나중에 lazy load 시 사용
+ *  5. writable 여부 저장
+ *  6. 생성한 page를 SPT에 삽입
+ *
+ * 성공 시 true 반환, 실패 시 false 반환
+ */
 bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
                                     vm_initializer *init, void *aux) {
-  ASSERT(VM_TYPE(type) != VM_UNINIT)
+  ASSERT(VM_TYPE(type) != VM_UNINIT)  // 타입이 UNINIT 자체로 들어오면 안 됨
 
   struct supplemental_page_table *spt = &thread_current()->spt;
 
-  /* Check wheter the upage is already occupied or not. */
+  /* 1. upage가 이미 SPT에 등록되어 있는지 확인 */
   if (spt_find_page(spt, upage) == NULL) {
+    /* 2. 새로운 page 구조체 동적 할당 */
     struct page *page = malloc(sizeof(struct page));
-
     if (!page)
-      goto err;
+      goto err;  // 메모리 부족 → 실패 처리
 
+    /* 3. 타입에 따라 실제 초기화 함수 선택 */
     typedef bool (*initializer_by_type)(struct page *, enum vm_type, void *);
     initializer_by_type initializer = NULL;
 
     switch (VM_TYPE(type)) {
-      case VM_ANON:
+      case VM_ANON:  // 익명 페이지
         initializer = anon_initializer;
         break;
-      case VM_FILE:
+      case VM_FILE:  // 파일 매핑 페이지
         initializer = file_backed_initializer;
         break;
     }
 
+    /* 4. "uninit" 페이지로 생성
+     *    - 실제 내용은 아직 로드되지 않음 (lazy load 예정)
+     *    - 나중에 page fault 발생 시 init()가 불려서 데이터 로드 */
     uninit_new(page, upage, init, type, aux, initializer);
+
+    /* 5. 페이지 속성 기록 (쓰기 가능 여부) */
     page->writable = writable;
 
+    /* 6. SPT에 삽입 → 성공 시 true 반환 */
     return spt_insert_page(spt, page);
   }
+
 err:
-  return false;
+  return false;  // 이미 존재하거나 메모리 부족 → 실패
 }
 
-/* Find VA from spt and return page. On error, return NULL. */
-// supplementary page table에서 va에 해당하는 구조체 페이지를 찾아 반환
+/*
+ * spt_find_page()
+ *
+ * - 주어진 가상 주소 va에 대응되는 페이지를 SPT에서 검색한다.
+ * - 내부적으로 hash_find()를 이용하여 spt_hash에서 조회한다.
+ * - 해시 키로 사용할 page 구조체를 임시로 생성하여
+ *   같은 va를 가진 hash_elem을 찾는다.
+ * - 찾으면 해당 struct page를 반환, 없으면 NULL 반환.
+ */
 struct page *
 spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+  /* 1. 비교용 임시 page 구조체 생성 */
   struct page *page = (struct page *)malloc(sizeof(struct page));
+
+  /* 2. va를 페이지 크기(PGSIZE) 단위로 내림 정렬 → 페이지 기준 주소 */
   page->va = pg_round_down(va);
+
+  /* 3. 해시 테이블에서 같은 va를 가진 page 탐색 */
   struct hash_elem *e = hash_find(&spt->spt_hash, &page->hash_elem);
+
+  /* 4. 임시로 만든 page는 필요 없으므로 해제 */
   free(page);
 
+  /* 5. 찾았으면 struct page*로 변환해서 반환, 없으면 NULL */
   return e != NULL ? hash_entry(e, struct page, hash_elem) : NULL;
 }
-/* Insert PAGE into spt with validation. */
-// supplementary page table에 struct page를 삽입
-// 가상 주소가 이미 supplementary page table에 존재하면 삽입하지 않고, 존재하지 않으면 삽입
+
+/*
+ * spt_insert_page()
+ *
+ * - 새로운 page를 SPT에 삽입한다.
+ * - 삽입 시 동일한 va가 이미 존재하면 실패(false) 반환.
+ * - 성공적으로 삽입 시 true 반환.
+ */
 bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
                      struct page *page UNUSED) {
+  /* hash_insert는 삽입 실패 시 기존 요소의 포인터를 반환,
+   * 성공 시 NULL을 반환한다.
+   * 따라서 NULL이 아니면 이미 존재하는 것 → false */
   return hash_insert(&spt->spt_hash, &page->hash_elem) ? false : true;
 }
 
+/*
+ * spt_remove_page()
+ *
+ * - 주어진 page를 SPT에서 제거한다.
+ * - 단순히 해시에서 제거하는 게 아니라,
+ *   page에 연결된 자원(프레임, 메모리 등)을 해제해야 한다.
+ * - vm_dealloc_page()를 호출해 파괴(destroy) 및 free까지 진행.
+ */
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
   vm_dealloc_page(page);
-  return true;
+  return true;  // ⚠️ 원형이 void인데 true 반환 → 수정 필요
 }
 
 /* Get the struct frame, that will be evicted. */
@@ -128,30 +175,48 @@ vm_evict_frame(void) {
   return NULL;
 }
 
-/* palloc() and get frame. If there is no available page, evict the page
- * and return it. This always return valid address. That is, if the user pool
- * memory is full, this function evicts the frame to get the available memory
- * space.*/
-
-// palloc_get_page 함수를 호출하여 사용자 풀에서 새로운 physical page(frame)를 가져옴
-// 사용 가능한 page가 없다면 swap out을 수행
+/*
+ * vm_get_frame()
+ *
+ * - 사용자 풀(User Pool)에서 새로운 물리 프레임을 할당한다.
+ * - 만약 할당할 수 있는 물리 프레임이 없으면, 페이지 교체(eviction)를 통해
+ *   프레임을 확보한다.
+ * - 최종적으로 유효한 프레임을 반환한다.
+ */
 static struct frame *
 vm_get_frame(void) {
   struct frame *frame = NULL;
-  /* TODO: Fill this function. */
-  struct frame *frame = (struct frame *)malloc(sizeof(struct frame));
+
+  /* 1. 프레임 구조체 자체를 동적 할당한다.
+   *    - frame 구조체는 커널 영역에 존재하며,
+   *      kva(물리 주소)와 page(연결된 페이지)를 저장한다. */
+  frame = (struct frame *)malloc(sizeof(struct frame));
   ASSERT(frame != NULL);
 
+  /* 2. 사용자 풀에서 실제 물리 메모리 1페이지를 얻는다.
+   *    - PAL_USER: 사용자 영역에서 할당
+   *    - PAL_ZERO: 페이지를 0으로 초기화 */
   frame->kva = palloc_get_page(PAL_USER | PAL_ZERO);
 
+  /* 3. 물리 페이지를 얻지 못했을 경우 → 프레임이 가득 찼다는 뜻
+   *    - 이때는 교체 정책(eviction policy)을 통해
+   *      victim frame을 골라 swap out 한 뒤 프레임을 회수해야 한다. */
   if (frame->kva == NULL)
     frame = vm_evict_frame();
   else
+    /* 4. 정상적으로 프레임을 확보했다면
+     *    frame_table (글로벌 프레임 리스트)에 추가한다.
+     *    - 이 리스트는 교체 알고리즘에서 victim 선택할 때 사용됨 */
     list_push_back(&frame_table, &frame->frame_elem);
 
+  /* 5. 새로 생성한 프레임은 아직 어떤 페이지와도 연결되지 않았다.
+   *    따라서 초기값으로 NULL을 설정. */
   frame->page = NULL;
 
+  /* 6. 방금 만든 프레임은 페이지와 연결되지 않은 상태여야 한다는 검증 */
   ASSERT(frame->page == NULL);
+
+  /* 7. 유효한 프레임 반환 */
   return frame;
 }
 
@@ -183,35 +248,56 @@ void vm_dealloc_page(struct page *page) {
   free(page);
 }
 
-/* Claim the page that allocate on VA. */
-// 인자로 주어진 va에 페이지를 하나 할당
-//  해당 페이지로 vm_do_claim_page를 호출
+/*
+ * vm_claim_page()
+ *
+ * - 주어진 가상 주소 va 에 해당하는 페이지를 SPT에서 찾아서
+ *   실제 물리 프레임을 할당(Claim)하고 매핑까지 완료하는 함수.
+ * - 즉, "이 주소의 페이지를 실제 메모리에 올려라"라는 요청을 수행.
+ */
 bool vm_claim_page(void *va UNUSED) {
   struct page *page = NULL;
-  struct page *page = spt_find_page(&thread_current()->spt, va);
+
+  /* SPT에서 va에 해당하는 페이지 구조체를 검색한다.
+   * 만약 존재하지 않으면 (즉, 아직 관리되지 않는 주소라면) 실패 처리. */
+  page = spt_find_page(&thread_current()->spt, va);
 
   if (page == NULL)
     return false;
 
+  /* 페이지를 실제 물리 프레임에 할당하고 매핑하는 작업 진행 */
   return vm_do_claim_page(page);
 }
 
-/* Claim the PAGE and set up the mmu. */
-// vm_get_frame() 함수를 통해 프레임 하나를 얻음
-// 프레임의 페이지로 얻은 페이지를 연결
-// 프레임의 물리적 주소로 얻은 프레임을 연결
-// 현재 페이지 테이블에 가상 주소에 따른 frame을 매핑
-static bool
-vm_do_claim_page(struct page *page) {
+/*
+ * vm_do_claim_page()
+ *
+ * - 실제로 페이지를 물리 프레임과 연결하고,
+ *   MMU(Page Table)에 매핑을 설정하는 함수.
+ */
+static bool vm_do_claim_page(struct page *page) {
+  /* 1. 사용자 풀에서 새 물리 프레임을 가져온다.
+   *    만약 여유 공간이 없다면, swap out 으로 victim 교체가 일어날 수도 있음. */
   struct frame *frame = vm_get_frame();
 
-  /* Set links */
+  /* 2. 양방향 연결 설정
+   *    - frame이 어떤 page에 속하는지 기록
+   *    - page가 어떤 frame을 사용하는지 기록 */
   frame->page = page;
   page->frame = frame;
 
+  /* 3. 페이지 테이블에 (page->va → frame->kva) 매핑 추가
+   *    - pml4_set_page: 현재 스레드의 pml4(Page Map Level 4, top-level PT)에
+   *      가상주소와 물리주소를 매핑한다.
+   *    - writable 플래그에 따라 쓰기 가능 여부를 설정한다.
+   *    - 실패하면 false 반환. */
   if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable))
     return false;
 
+  /* 4. 페이지 타입에 맞게 실제 데이터를 메모리에 적재 (swap_in 호출)
+   *    - 예: Lazy load의 경우 파일에서 읽어오기
+   *    - 익명 페이지(anon)의 경우 swap disk에서 가져오기
+   *    - 성공하면 true, 실패하면 false */
   return swap_in(page, frame->kva);
 }
 
@@ -231,19 +317,28 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
    * TODO: writeback all the modified contents to the storage. */
 }
 
-// spt에 넣을 인덱스를 해시 함수를 돌려서 도출
-// hash table이 hash elem을 원소로 가지고 있으므로 페이지 자체에 대한 정보를 가져옴
-// 인덱스를 리턴해야하므로 hash_bytes로 리턴
+/*
+ * Hash function for supplemental page table (SPT).
+ *
+ * - 해시 테이블에서 특정 page 를 저장할 때 사용할 해시 값 계산 함수.
+ * - struct page 의 가상 주소 (page->va)를 기반으로 해시를 생성한다.
+ * - hash_bytes(): 주어진 메모리 블록을 바이트 단위로 해싱하는 Pintos 유틸 함수.
+ * - 결국 동일한 가상 주소를 가진 page 는 동일한 해시 값으로 매핑됨.
+ */
 uint64_t
-page_hash(const struct hash_elem *e, void *aux) {
+page_hash(const struct hash_elem *e, void *aux UNUSED) {
   struct page *page = hash_entry(e, struct page, hash_elem);
-  return hash_bytes(page->va, sizeof *page->va);
+  return hash_bytes(&page->va, sizeof page->va);
 }
 
-// 체이닝 방식의 spt를 구현하기 위한 함수
-// 해시 테이블 버킷 내의 두 페이지의 주소값을 비교
-
-bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux) {
+/*
+ * Comparison function for supplemental page table (SPT).
+ *
+ * - 해시 테이블에서 같은 버킷에 충돌이 발생했을 때 원소 간 정렬을 위해 사용된다.
+ * - 두 struct page 의 가상 주소 (va)를 비교하여 작은 쪽이 앞으로 오도록 정렬한다.
+ * - 결국 해시 테이블 내부에서 page 들은 va 기준 오름차순으로 정리됨.
+ */
+bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux UNUSED) {
   struct page *page_a = hash_entry(a, struct page, hash_elem);
   struct page *page_b = hash_entry(b, struct page, hash_elem);
 

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -59,136 +59,144 @@ err:
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
+// supplementary page table에서 va에 해당하는 구조체 페이지를 찾아 반환
 struct page *
 spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-  struct page *page = NULL;
-  /* TODO: Fill this function. */
-
-  return page;
-}
-
-/* Insert PAGE into spt with validation. */
-bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
-                     struct page *page UNUSED) {
-  int succ = false;
-  /* TODO: Fill this function. */
-
-  return succ;
-}
-
-void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
-  vm_dealloc_page(page);
-  return true;
-}
-
-/* Get the struct frame, that will be evicted. */
-static struct frame *
-vm_get_victim(void) {
-  struct frame *victim = NULL;
-  /* TODO: The policy for eviction is up to you. */
-
-  return victim;
-}
-
-/* Evict one page and return the corresponding frame.
- * Return NULL on error.*/
-static struct frame *
-vm_evict_frame(void) {
-  struct frame *victim UNUSED = vm_get_victim();
-  /* TODO: swap out the victim and return the evicted frame. */
-
-  return NULL;
-}
-
-/* palloc() and get frame. If there is no available page, evict the page
- * and return it. This always return valid address. That is, if the user pool
- * memory is full, this function evicts the frame to get the available memory
- * space.*/
-static struct frame *
-vm_get_frame(void) {
-  struct frame *frame = NULL;
-  /* TODO: Fill this function. */
-
-  ASSERT(frame != NULL);
-  ASSERT(frame->page == NULL);
-  return frame;
-}
-
-/* Growing the stack. */
-static void
-vm_stack_growth(void *addr UNUSED) {
-}
-
-/* Handle the fault on write_protected page */
-static bool
-vm_handle_wp(struct page *page UNUSED) {
-}
-
-/* Return true on success */
-bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
-                         bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-  struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
-  struct page *page = NULL;
-  /* TODO: Validate the fault */
-  /* TODO: Your code goes here */
-
-  return vm_do_claim_page(page);
-}
-
-/* Free the page.
- * DO NOT MODIFY THIS FUNCTION. */
-void vm_dealloc_page(struct page *page) {
-  destroy(page);
+  struct page *page = (struct page *)malloc(sizeof(struct page));
+  page->va = pg_round_down(va);
+  struct hash_elem *e = hash_find(&spt->spt_hash, &page->hash_elem);
   free(page);
-}
 
-/* Claim the page that allocate on VA. */
-bool vm_claim_page(void *va UNUSED) {
-  struct page *page = NULL;
-  /* TODO: Fill this function */
+  return e != NULL ? hash_entry(e, struct page, hash_elem) : NULL;
 
-  return vm_do_claim_page(page);
-}
+  /* Insert PAGE into spt with validation. */
+  bool spt_insert_page(struct supplemental_page_table * spt UNUSED,
+                       struct page * page UNUSED) {
+    int succ = false;
+    /* TODO: Fill this function. */
 
-/* Claim the PAGE and set up the mmu. */
-static bool
-vm_do_claim_page(struct page *page) {
-  struct frame *frame = vm_get_frame();
+    return succ;
+  }
 
-  /* Set links */
-  frame->page = page;
-  page->frame = frame;
+  void spt_remove_page(struct supplemental_page_table * spt, struct page * page) {
+    vm_dealloc_page(page);
+    return true;
+  }
 
-  /* TODO: Insert page table entry to map page's VA to frame's PA. */
+  /* Get the struct frame, that will be evicted. */
+  static struct frame *
+  vm_get_victim(void) {
+    struct frame *victim = NULL;
+    /* TODO: The policy for eviction is up to you. */
 
-  return swap_in(page, frame->kva);
-}
+    return victim;
+  }
 
-/* Initialize new supplemental page table */
-void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
-  hash_init(spt, page_hash, page_less, NULL);  // spt 초기화
-}
+  /* Evict one page and return the corresponding frame.
+   * Return NULL on error.*/
+  static struct frame *
+  vm_evict_frame(void) {
+    struct frame *victim UNUSED = vm_get_victim();
+    /* TODO: swap out the victim and return the evicted frame. */
 
-/* Copy supplemental page table from src to dst */
-bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
-                                  struct supplemental_page_table *src UNUSED) {
-}
+    return NULL;
+  }
 
-/* Free the resource hold by the supplemental page table */
-void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
-  /* TODO: Destroy all the supplemental_page_table hold by thread and
-   * TODO: writeback all the modified contents to the storage. */
-}
+  /* palloc() and get frame. If there is no available page, evict the page
+   * and return it. This always return valid address. That is, if the user pool
+   * memory is full, this function evicts the frame to get the available memory
+   * space.*/
+  static struct frame *
+  vm_get_frame(void) {
+    struct frame *frame = NULL;
+    /* TODO: Fill this function. */
 
-uint64_t
-page_hash(const struct hash_elem *e, void *aux) {
-  struct page *page = hash_entry(e, struct page, hash_elem);
-  return hash_bytes(page->va, sizeof *page->va);
-}
+    ASSERT(frame != NULL);
+    ASSERT(frame->page == NULL);
+    return frame;
+  }
 
-bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux) {
-  struct page *page_a = hash_entry(a, struct page, hash_elem);
-  struct page *page_b = hash_entry(b, struct page, hash_elem);
+  /* Growing the stack. */
+  static void
+  vm_stack_growth(void *addr UNUSED) {
+  }
 
-  return page_a->va < page_b->va;
-}
+  /* Handle the fault on write_protected page */
+  static bool
+  vm_handle_wp(struct page * page UNUSED) {
+  }
+
+  /* Return true on success */
+  bool vm_try_handle_fault(struct intr_frame * f UNUSED, void *addr UNUSED,
+                           bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+    struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
+    struct page *page = NULL;
+    /* TODO: Validate the fault */
+    /* TODO: Your code goes here */
+
+    return vm_do_claim_page(page);
+  }
+
+  /* Free the page.
+   * DO NOT MODIFY THIS FUNCTION. */
+  void vm_dealloc_page(struct page * page) {
+    destroy(page);
+    free(page);
+  }
+
+  /* Claim the page that allocate on VA. */
+  bool vm_claim_page(void *va UNUSED) {
+    struct page *page = NULL;
+    /* TODO: Fill this function */
+
+    return vm_do_claim_page(page);
+  }
+
+  /* Claim the PAGE and set up the mmu. */
+  static bool
+  vm_do_claim_page(struct page * page) {
+    struct frame *frame = vm_get_frame();
+
+    /* Set links */
+    frame->page = page;
+    page->frame = frame;
+
+    /* TODO: Insert page table entry to map page's VA to frame's PA. */
+
+    return swap_in(page, frame->kva);
+  }
+
+  /* Initialize new supplemental page table */
+  void supplemental_page_table_init(struct supplemental_page_table * spt UNUSED) {
+    hash_init(spt, page_hash, page_less, NULL);  // spt 초기화
+  }
+
+  /* Copy supplemental page table from src to dst */
+  bool supplemental_page_table_copy(struct supplemental_page_table * dst UNUSED,
+                                    struct supplemental_page_table * src UNUSED) {
+  }
+
+  /* Free the resource hold by the supplemental page table */
+  void supplemental_page_table_kill(struct supplemental_page_table * spt UNUSED) {
+    /* TODO: Destroy all the supplemental_page_table hold by thread and
+     * TODO: writeback all the modified contents to the storage. */
+  }
+
+  // spt에 넣을 인덱스를 해시 함수를 돌려서 도출
+  // hash table이 hash elem을 원소로 가지고 있으므로 페이지 자체에 대한 정보를 가져옴
+  // 인덱스를 리턴해야하므로 hash_bytes로 리턴
+  uint64_t
+  page_hash(const struct hash_elem *e, void *aux) {
+    struct page *page = hash_entry(e, struct page, hash_elem);
+    return hash_bytes(page->va, sizeof *page->va);
+  }
+
+  // 체이닝 방식의 spt를 구현하기 위한 함수
+  // 해시 테이블 버킷 내의 두 페이지의 주소값을 비교
+
+  bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux) {
+    struct page *page_a = hash_entry(a, struct page, hash_elem);
+    struct page *page_b = hash_entry(b, struct page, hash_elem);
+
+    return page_a->va < page_b->va;
+  }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -160,9 +160,14 @@ void vm_dealloc_page(struct page *page) {
 }
 
 /* Claim the page that allocate on VA. */
+// 인자로 주어진 va에 페이지를 하나 할당
+//  해당 페이지로 vm_do_claim_page를 호출
 bool vm_claim_page(void *va UNUSED) {
   struct page *page = NULL;
-  /* TODO: Fill this function */
+  struct page *page = spt_find_page(&thread_current()->spt, va);
+
+  if (page == NULL)
+    return false;
 
   return vm_do_claim_page(page);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -6,7 +6,8 @@
 #include "threads/mmu.h"
 #include "vm/inspect.h"
 
-static struct list frame_table;  // 구조체 추가
+static struct list frame_table; // 구조체 추가
+static bool is_valid_stack_access(void* addr, const uintptr_t rsp);
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -19,14 +20,13 @@ void vm_init(void) {
   register_inspect_intr();
   /* DO NOT MODIFY UPPER LINES. */
   /* TODO: Your code goes here. */
-  list_init(&frame_table);  // 구조체 초기화
+  list_init(&frame_table); // 구조체 초기화
 }
 
 /* Get the type of the page. This function is useful if you want to know the
  * type of the page after it will be initialized.
  * This function is fully implemented now. */
-enum vm_type
-page_get_type(struct page *page) {
+enum vm_type page_get_type(struct page *page) {
   int ty = VM_TYPE(page->operations->type);
   switch (ty) {
     case VM_UNINIT:
@@ -61,7 +61,7 @@ static struct frame *vm_evict_frame(void);
  */
 bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
                                     vm_initializer *init, void *aux) {
-  ASSERT(VM_TYPE(type) != VM_UNINIT)  // 타입이 UNINIT 자체로 들어오면 안 됨
+  ASSERT(VM_TYPE(type) != VM_UNINIT) // 타입이 UNINIT 자체로 들어오면 안 됨
 
   struct supplemental_page_table *spt = &thread_current()->spt;
 
@@ -69,18 +69,17 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   if (spt_find_page(spt, upage) == NULL) {
     /* 2. 새로운 page 구조체 동적 할당 */
     struct page *page = malloc(sizeof(struct page));
-    if (!page)
-      goto err;  // 메모리 부족 → 실패 처리
+    if (!page) goto err; // 메모리 부족 → 실패 처리
 
     /* 3. 타입에 따라 실제 초기화 함수 선택 */
     typedef bool (*initializer_by_type)(struct page *, enum vm_type, void *);
     initializer_by_type initializer = NULL;
 
     switch (VM_TYPE(type)) {
-      case VM_ANON:  // 익명 페이지
+      case VM_ANON: // 익명 페이지
         initializer = anon_initializer;
         break;
-      case VM_FILE:  // 파일 매핑 페이지
+      case VM_FILE: // 파일 매핑 페이지
         initializer = file_backed_initializer;
         break;
     }
@@ -98,7 +97,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   }
 
 err:
-  return false;  // 이미 존재하거나 메모리 부족 → 실패
+  return false; // 이미 존재하거나 메모리 부족 → 실패
 }
 
 /*
@@ -110,8 +109,7 @@ err:
  *   같은 va를 가진 hash_elem을 찾는다.
  * - 찾으면 해당 struct page를 반환, 없으면 NULL 반환.
  */
-struct page *
-spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
   /* 1. 비교용 임시 page 구조체 생성 */
   struct page page;
 
@@ -154,8 +152,7 @@ void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
 }
 
 /* Get the struct frame, that will be evicted. */
-static struct frame *
-vm_get_victim(void) {
+static struct frame *vm_get_victim(void) {
   struct frame *victim = NULL;
   /* TODO: The policy for eviction is up to you. */
 
@@ -164,8 +161,7 @@ vm_get_victim(void) {
 
 /* Evict one page and return the corresponding frame.
  * Return NULL on error.*/
-static struct frame *
-vm_evict_frame(void) {
+static struct frame *vm_evict_frame(void) {
   struct frame *victim UNUSED = vm_get_victim();
   /* TODO: swap out the victim and return the evicted frame. */
 
@@ -180,8 +176,7 @@ vm_evict_frame(void) {
  *   프레임을 확보한다.
  * - 최종적으로 유효한 프레임을 반환한다.
  */
-static struct frame *
-vm_get_frame(void) {
+static struct frame *vm_get_frame(void) {
   struct frame *frame = NULL;
 
   /* 1. 프레임 구조체 자체를 동적 할당한다.
@@ -198,8 +193,7 @@ vm_get_frame(void) {
   /* 3. 물리 페이지를 얻지 못했을 경우 → 프레임이 가득 찼다는 뜻
    *    - 이때는 교체 정책(eviction policy)을 통해
    *      victim frame을 골라 swap out 한 뒤 프레임을 회수해야 한다. */
-  if (frame->kva == NULL)
-    frame = vm_evict_frame();
+  if (frame->kva == NULL) frame = vm_evict_frame();
   else
     /* 4. 정상적으로 프레임을 확보했다면
      *    frame_table (글로벌 프레임 리스트)에 추가한다.
@@ -218,24 +212,53 @@ vm_get_frame(void) {
 }
 
 /* Growing the stack. */
-static void
-vm_stack_growth(void *addr UNUSED) {
+static void vm_stack_growth(void *addr UNUSED) {
 }
 
 /* Handle the fault on write_protected page */
-static bool
-vm_handle_wp(struct page *page UNUSED) {
+static bool vm_handle_wp(struct page *page UNUSED) {
 }
 
 /* Return true on success */
-bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
-                         bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-  struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
-  struct page *page = NULL;
-  /* TODO: Validate the fault */
-  /* TODO: Your code goes here */
+bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write, bool not_present) {
+  struct supplemental_page_table* spt = &thread_current()->spt;
+  struct page* page = NULL;
+  // ============================================
+  // Step 1: 주소 정렬 및 기본 검증
+  // ============================================
 
-  return vm_do_claim_page(page);
+  // 1: addr을 페이지 단위로 정렬
+  // 페이지 시작 주소로 정렬
+  void *page_addr = pg_round_down(addr);
+
+  // 2: User 영역인지 확인 : 보안
+  if (!is_user_vaddr(page_addr)) {
+    return false;
+  }
+
+  // ============================================
+  // Step 2: SPT에서 페이지 찾기
+  // ============================================
+
+  page = spt_find_page(spt, page_addr);
+
+  if (page != NULL) {
+    return vm_do_claim_page(page);
+  }
+
+  // ============================================
+  // Step 3: Stack Growth 확인
+  // ============================================
+  // rsp 근처인지, stack 영역인지, 1MB 제한을 넘었는지 (1 << 20 = 1MB)
+  if (is_valid_stack_access(page_addr, f->rsp)) {
+    vm_stack_growth(page_addr);
+    return true;
+  }
+
+  // ============================================
+  // Step 4: Invalid Access 처리
+  // ============================================
+  return false;
 }
 
 /* Free the page.
@@ -259,8 +282,7 @@ bool vm_claim_page(void *va UNUSED) {
    * 만약 존재하지 않으면 (즉, 아직 관리되지 않는 주소라면) 실패 처리. */
   page = spt_find_page(&thread_current()->spt, va);
 
-  if (page == NULL)
-    return false;
+  if (page == NULL) return false;
 
   /* 페이지를 실제 물리 프레임에 할당하고 매핑하는 작업 진행 */
   return vm_do_claim_page(page);
@@ -288,8 +310,7 @@ static bool vm_do_claim_page(struct page *page) {
    *      가상주소와 물리주소를 매핑한다.
    *    - writable 플래그에 따라 쓰기 가능 여부를 설정한다.
    *    - 실패하면 false 반환. */
-  if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable))
-    return false;
+  if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)) return false;
 
   /* 4. 페이지 타입에 맞게 실제 데이터를 메모리에 적재 (swap_in 호출)
    *    - 예: Lazy load의 경우 파일에서 읽어오기
@@ -300,7 +321,7 @@ static bool vm_do_claim_page(struct page *page) {
 
 /* Initialize new supplemental page table */
 void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
-  hash_init(spt, page_hash, page_less, NULL);  // spt 초기화
+  hash_init(spt, page_hash, page_less, NULL); // spt 초기화
 }
 
 /* Copy supplemental page table from src to dst */
@@ -322,8 +343,7 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
  * - hash_bytes(): 주어진 메모리 블록을 바이트 단위로 해싱하는 Pintos 유틸 함수.
  * - 결국 동일한 가상 주소를 가진 page 는 동일한 해시 값으로 매핑됨.
  */
-uint64_t
-page_hash(const struct hash_elem *e, void *aux UNUSED) {
+uint64_t page_hash(const struct hash_elem *e, void *aux UNUSED) {
   struct page *page = hash_entry(e, struct page, hash_elem);
   return hash_bytes(&page->va, sizeof page->va);
 }
@@ -340,4 +360,17 @@ bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux U
   struct page *page_b = hash_entry(b, struct page, hash_elem);
 
   return page_a->va < page_b->va;
+}
+
+static bool is_valid_stack_access(void* addr, const uintptr_t rsp) {
+  uintptr_t fault_addr = (uintptr_t)addr;
+
+  // stack 영역 확인
+  if (fault_addr >= USER_STACK) return false;
+  // rsp 근처 확인
+  if (fault_addr < rsp - 32) return false;
+  // 1MB 제한 확인
+  if (USER_STACK - fault_addr > (1 << 20)) return false;
+
+  return true;
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -113,18 +113,15 @@ err:
 struct page *
 spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
   /* 1. 비교용 임시 page 구조체 생성 */
-  struct page *page = (struct page *)malloc(sizeof(struct page));
+  struct page page;
 
   /* 2. va를 페이지 크기(PGSIZE) 단위로 내림 정렬 → 페이지 기준 주소 */
-  page->va = pg_round_down(va);
+  page.va = pg_round_down(va);
 
   /* 3. 해시 테이블에서 같은 va를 가진 page 탐색 */
-  struct hash_elem *e = hash_find(&spt->spt_hash, &page->hash_elem);
+  struct hash_elem *e = hash_find(&spt->spt_hash, &page.hash_elem);
 
-  /* 4. 임시로 만든 page는 필요 없으므로 해제 */
-  free(page);
-
-  /* 5. 찾았으면 struct page*로 변환해서 반환, 없으면 NULL */
+  /* 4. 찾았으면 struct page*로 변환해서 반환, 없으면 NULL */
   return e != NULL ? hash_entry(e, struct page, hash_elem) : NULL;
 }
 
@@ -152,8 +149,8 @@ bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
  * - vm_dealloc_page()를 호출해 파괴(destroy) 및 free까지 진행.
  */
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
+  hash_delete(&spt->spt_hash, &page->hash_elem);
   vm_dealloc_page(page);
-  return true;  // ⚠️ 원형이 void인데 true 반환 → 수정 필요
 }
 
 /* Get the struct frame, that will be evicted. */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -1,107 +1,103 @@
 /* vm.c: Generic interface for virtual memory objects. */
 
-#include "threads/malloc.h"
 #include "vm/vm.h"
+
+#include "threads/malloc.h"
 #include "vm/inspect.h"
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
-void
-vm_init (void) {
-	vm_anon_init ();
-	vm_file_init ();
-#ifdef EFILESYS  /* For project 4 */
-	pagecache_init ();
+void vm_init(void) {
+  vm_anon_init();
+  vm_file_init();
+#ifdef EFILESYS /* For project 4 */
+  pagecache_init();
 #endif
-	register_inspect_intr ();
-	/* DO NOT MODIFY UPPER LINES. */
-	/* TODO: Your code goes here. */
+  register_inspect_intr();
+  /* DO NOT MODIFY UPPER LINES. */
+  /* TODO: Your code goes here. */
 }
 
 /* Get the type of the page. This function is useful if you want to know the
  * type of the page after it will be initialized.
  * This function is fully implemented now. */
 enum vm_type
-page_get_type (struct page *page) {
-	int ty = VM_TYPE (page->operations->type);
-	switch (ty) {
-		case VM_UNINIT:
-			return VM_TYPE (page->uninit.type);
-		default:
-			return ty;
-	}
+page_get_type(struct page *page) {
+  int ty = VM_TYPE(page->operations->type);
+  switch (ty) {
+    case VM_UNINIT:
+      return VM_TYPE(page->uninit.type);
+    default:
+      return ty;
+  }
 }
 
 /* Helpers */
-static struct frame *vm_get_victim (void);
-static bool vm_do_claim_page (struct page *page);
-static struct frame *vm_evict_frame (void);
+static struct frame *vm_get_victim(void);
+static bool vm_do_claim_page(struct page *page);
+static struct frame *vm_evict_frame(void);
 
 /* Create the pending page object with initializer. If you want to create a
  * page, do not create it directly and make it through this function or
  * `vm_alloc_page`. */
-bool
-vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
-		vm_initializer *init, void *aux) {
+bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
+                                    vm_initializer *init, void *aux) {
+  ASSERT(VM_TYPE(type) != VM_UNINIT)
 
-	ASSERT (VM_TYPE(type) != VM_UNINIT)
+  struct supplemental_page_table *spt = &thread_current()->spt;
 
-	struct supplemental_page_table *spt = &thread_current ()->spt;
+  /* Check wheter the upage is already occupied or not. */
+  if (spt_find_page(spt, upage) == NULL) {
+    /* TODO: Create the page, fetch the initialier according to the VM type,
+     * TODO: and then create "uninit" page struct by calling uninit_new. You
+     * TODO: should modify the field after calling the uninit_new. */
 
-	/* Check wheter the upage is already occupied or not. */
-	if (spt_find_page (spt, upage) == NULL) {
-		/* TODO: Create the page, fetch the initialier according to the VM type,
-		 * TODO: and then create "uninit" page struct by calling uninit_new. You
-		 * TODO: should modify the field after calling the uninit_new. */
-
-		/* TODO: Insert the page into the spt. */
-	}
+    /* TODO: Insert the page into the spt. */
+  }
 err:
-	return false;
+  return false;
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
 struct page *
-spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = NULL;
-	/* TODO: Fill this function. */
+spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+  struct page *page = NULL;
+  /* TODO: Fill this function. */
 
-	return page;
+  return page;
 }
 
 /* Insert PAGE into spt with validation. */
-bool
-spt_insert_page (struct supplemental_page_table *spt UNUSED,
-		struct page *page UNUSED) {
-	int succ = false;
-	/* TODO: Fill this function. */
+bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
+                     struct page *page UNUSED) {
+  int succ = false;
+  /* TODO: Fill this function. */
 
-	return succ;
+  return succ;
 }
 
-void
-spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
-	vm_dealloc_page (page);
-	return true;
+void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
+  vm_dealloc_page(page);
+  return true;
 }
 
 /* Get the struct frame, that will be evicted. */
 static struct frame *
-vm_get_victim (void) {
-	struct frame *victim = NULL;
-	 /* TODO: The policy for eviction is up to you. */
+vm_get_victim(void) {
+  struct frame *victim = NULL;
+  /* TODO: The policy for eviction is up to you. */
 
-	return victim;
+  return victim;
 }
 
 /* Evict one page and return the corresponding frame.
  * Return NULL on error.*/
 static struct frame *
-vm_evict_frame (void) {
-	struct frame *victim UNUSED = vm_get_victim ();
-	/* TODO: swap out the victim and return the evicted frame. */
+vm_evict_frame(void) {
+  struct frame *victim UNUSED = vm_get_victim();
+  /* TODO: swap out the victim and return the evicted frame. */
 
-	return NULL;
+  return NULL;
 }
 
 /* palloc() and get frame. If there is no available page, evict the page
@@ -109,82 +105,77 @@ vm_evict_frame (void) {
  * memory is full, this function evicts the frame to get the available memory
  * space.*/
 static struct frame *
-vm_get_frame (void) {
-	struct frame *frame = NULL;
-	/* TODO: Fill this function. */
+vm_get_frame(void) {
+  struct frame *frame = NULL;
+  /* TODO: Fill this function. */
 
-	ASSERT (frame != NULL);
-	ASSERT (frame->page == NULL);
-	return frame;
+  ASSERT(frame != NULL);
+  ASSERT(frame->page == NULL);
+  return frame;
 }
 
 /* Growing the stack. */
 static void
-vm_stack_growth (void *addr UNUSED) {
+vm_stack_growth(void *addr UNUSED) {
 }
 
 /* Handle the fault on write_protected page */
 static bool
-vm_handle_wp (struct page *page UNUSED) {
+vm_handle_wp(struct page *page UNUSED) {
 }
 
 /* Return true on success */
-bool
-vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
-		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
-	struct page *page = NULL;
-	/* TODO: Validate the fault */
-	/* TODO: Your code goes here */
+bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
+                         bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+  struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
+  struct page *page = NULL;
+  /* TODO: Validate the fault */
+  /* TODO: Your code goes here */
 
-	return vm_do_claim_page (page);
+  return vm_do_claim_page(page);
 }
 
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
-void
-vm_dealloc_page (struct page *page) {
-	destroy (page);
-	free (page);
+void vm_dealloc_page(struct page *page) {
+  destroy(page);
+  free(page);
 }
 
 /* Claim the page that allocate on VA. */
-bool
-vm_claim_page (void *va UNUSED) {
-	struct page *page = NULL;
-	/* TODO: Fill this function */
+bool vm_claim_page(void *va UNUSED) {
+  struct page *page = NULL;
+  /* TODO: Fill this function */
 
-	return vm_do_claim_page (page);
+  return vm_do_claim_page(page);
 }
 
 /* Claim the PAGE and set up the mmu. */
 static bool
-vm_do_claim_page (struct page *page) {
-	struct frame *frame = vm_get_frame ();
+vm_do_claim_page(struct page *page) {
+  struct frame *frame = vm_get_frame();
 
-	/* Set links */
-	frame->page = page;
-	page->frame = frame;
+  /* Set links */
+  frame->page = page;
+  page->frame = frame;
 
-	/* TODO: Insert page table entry to map page's VA to frame's PA. */
+  /* TODO: Insert page table entry to map page's VA to frame's PA. */
 
-	return swap_in (page, frame->kva);
+  return swap_in(page, frame->kva);
 }
 
 /* Initialize new supplemental page table */
-void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
+void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
+  hash_init(spt, page_hash, page_less, NULL);  // spt 초기화
 }
 
 /* Copy supplemental page table from src to dst */
-bool
-supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) {
+bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
+                                  struct supplemental_page_table *src UNUSED) {
 }
 
 /* Free the resource hold by the supplemental page table */
-void
-supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
-	/* TODO: Destroy all the supplemental_page_table hold by thread and
-	 * TODO: writeback all the modified contents to the storage. */
+void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
+  /* TODO: Destroy all the supplemental_page_table hold by thread and
+   * TODO: writeback all the modified contents to the storage. */
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -5,6 +5,8 @@
 #include "threads/malloc.h"
 #include "vm/inspect.h"
 
+static struct list frame_table;  // 구조체 추가
+
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
 void vm_init(void) {
@@ -16,6 +18,7 @@ void vm_init(void) {
   register_inspect_intr();
   /* DO NOT MODIFY UPPER LINES. */
   /* TODO: Your code goes here. */
+  list_init(&frame_table);  // 구조체 초기화
 }
 
 /* Get the type of the page. This function is useful if you want to know the

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -6,8 +6,8 @@
 #include "threads/mmu.h"
 #include "vm/inspect.h"
 
-static struct list frame_table; // 구조체 추가
-static bool is_valid_stack_access(void* addr, const uintptr_t rsp);
+static struct list frame_table;  // 구조체 추가
+static bool is_valid_stack_access(void *addr, const uintptr_t rsp);
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -20,7 +20,7 @@ void vm_init(void) {
   register_inspect_intr();
   /* DO NOT MODIFY UPPER LINES. */
   /* TODO: Your code goes here. */
-  list_init(&frame_table); // 구조체 초기화
+  list_init(&frame_table);  // 구조체 초기화
 }
 
 /* Get the type of the page. This function is useful if you want to know the
@@ -61,7 +61,7 @@ static struct frame *vm_evict_frame(void);
  */
 bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
                                     vm_initializer *init, void *aux) {
-  ASSERT(VM_TYPE(type) != VM_UNINIT) // 타입이 UNINIT 자체로 들어오면 안 됨
+  ASSERT(VM_TYPE(type) != VM_UNINIT)  // 타입이 UNINIT 자체로 들어오면 안 됨
 
   struct supplemental_page_table *spt = &thread_current()->spt;
 
@@ -69,17 +69,17 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   if (spt_find_page(spt, upage) == NULL) {
     /* 2. 새로운 page 구조체 동적 할당 */
     struct page *page = malloc(sizeof(struct page));
-    if (!page) goto err; // 메모리 부족 → 실패 처리
+    if (!page) goto err;  // 메모리 부족 → 실패 처리
 
     /* 3. 타입에 따라 실제 초기화 함수 선택 */
     typedef bool (*initializer_by_type)(struct page *, enum vm_type, void *);
     initializer_by_type initializer = NULL;
 
     switch (VM_TYPE(type)) {
-      case VM_ANON: // 익명 페이지
+      case VM_ANON:  // 익명 페이지
         initializer = anon_initializer;
         break;
-      case VM_FILE: // 파일 매핑 페이지
+      case VM_FILE:  // 파일 매핑 페이지
         initializer = file_backed_initializer;
         break;
     }
@@ -97,7 +97,7 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
   }
 
 err:
-  return false; // 이미 존재하거나 메모리 부족 → 실패
+  return false;  // 이미 존재하거나 메모리 부족 → 실패
 }
 
 /*
@@ -193,7 +193,8 @@ static struct frame *vm_get_frame(void) {
   /* 3. 물리 페이지를 얻지 못했을 경우 → 프레임이 가득 찼다는 뜻
    *    - 이때는 교체 정책(eviction policy)을 통해
    *      victim frame을 골라 swap out 한 뒤 프레임을 회수해야 한다. */
-  if (frame->kva == NULL) frame = vm_evict_frame();
+  if (frame->kva == NULL)
+    frame = vm_evict_frame();
   else
     /* 4. 정상적으로 프레임을 확보했다면
      *    frame_table (글로벌 프레임 리스트)에 추가한다.
@@ -220,9 +221,9 @@ static bool vm_handle_wp(struct page *page UNUSED) {
 }
 
 /* Return true on success */
-bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write, bool not_present) {
-  struct supplemental_page_table* spt = &thread_current()->spt;
-  struct page* page = NULL;
+bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user, bool write, bool not_present) {
+  struct supplemental_page_table *spt = &thread_current()->spt;
+  struct page *page = NULL;
   // ============================================
   // Step 1: 주소 정렬 및 기본 검증
   // ============================================
@@ -321,7 +322,7 @@ static bool vm_do_claim_page(struct page *page) {
 
 /* Initialize new supplemental page table */
 void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
-  hash_init(spt, page_hash, page_less, NULL); // spt 초기화
+  hash_init(spt, page_hash, page_less, NULL);  // spt 초기화
 }
 
 /* Copy supplemental page table from src to dst */
@@ -362,7 +363,7 @@ bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux U
   return page_a->va < page_b->va;
 }
 
-static bool is_valid_stack_access(void* addr, const uintptr_t rsp) {
+static bool is_valid_stack_access(void *addr, const uintptr_t rsp) {
   uintptr_t fault_addr = (uintptr_t)addr;
 
   // stack 영역 확인

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -179,3 +179,9 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
   /* TODO: Destroy all the supplemental_page_table hold by thread and
    * TODO: writeback all the modified contents to the storage. */
 }
+
+uint64_t
+page_hash(const struct hash_elem *e, void *aux) {
+  struct page *page = hash_entry(e, struct page, hash_elem);
+  return hash_bytes(page->va, sizeof *page->va);
+}

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -185,3 +185,10 @@ page_hash(const struct hash_elem *e, void *aux) {
   struct page *page = hash_entry(e, struct page, hash_elem);
   return hash_bytes(page->va, sizeof *page->va);
 }
+
+bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux) {
+  struct page *page_a = hash_entry(a, struct page, hash_elem);
+  struct page *page_b = hash_entry(b, struct page, hash_elem);
+
+  return page_a->va < page_b->va;
+}


### PR DESCRIPTION
(procss.c)
load_segment(), lazy_load_segment(), setup_stack() 구현 및 수정

(vm.c)
supplemental_page_table_init()의 hash_init 첫 번째 인자 수정 (spt > &spt->spt_hash)
supplemental_page_table_copy() 구현
+
hash_action_destroy() 헬퍼함수
free_frame() 헬퍼함수 (process.c의 lazy_load_segment에서 사용)

![화면 캡처 2025-10-11 194452](https://github.com/user-attachments/assets/5b6eacdd-c7d2-453d-9bf3-2e7706c46cbb)
위 6항목 제외하고 1-63 pass
위 항목은 모두 exit(-1)

anon.c 하기 전에 여기까지 구현해서 pass 띄워놓고 시작하길래 먼저 구현하고 PR합니다.