### PR TITLE
anon.c 구현하기 전에 project2 테스트들 pass시키기 위한 사전 작업

### DIFF
--- a/pintos/include/devices/vga.h
+++ b/pintos/include/devices/vga.h
@@ -1,6 +1,7 @@
 #ifndef DEVICES_VGA_H
 #define DEVICES_VGA_H
 
-void vga_putc (int);
+void vga_putc(int);
 
 #endif /* devices/vga.h */
+       // test

--- a/pintos/include/devices/vga.h
+++ b/pintos/include/devices/vga.h
@@ -1,7 +1,6 @@
 #ifndef DEVICES_VGA_H
 #define DEVICES_VGA_H
 
-void vga_putc(int);
+void vga_putc (int);
 
 #endif /* devices/vga.h */
-       // test

--- a/pintos/include/vm/anon.h
+++ b/pintos/include/vm/anon.h
@@ -5,9 +5,10 @@ struct page;
 enum vm_type;
 
 struct anon_page {
+  uint8_t swap_index;
 };
 
-void vm_anon_init (void);
-bool anon_initializer (struct page *page, enum vm_type type, void *kva);
+void vm_anon_init(void);
+bool anon_initializer(struct page *page, enum vm_type type, void *kva);
 
 #endif

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -127,4 +127,5 @@ enum vm_type page_get_type(struct page *page);
 
 uint64_t page_hash(const struct hash_elem *e, void *aux);  // 선언
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
+void hash_action_destroy(struct hash_elem *hash_elem_, void *aux);
 #endif /* VM_VM_H */

--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -94,6 +94,15 @@ struct supplemental_page_table {
   struct hash spt_hash;  // 해시 구조체 추가
 };
 
+/* process.c load_segment의 vm_alloc_page_with_initializer의 네 번째 인자인
+ * lazy_load_segment 함수에 전달될 인자 aux구조체 */
+struct file_loader {
+  size_t page_read_bytes;
+  size_t page_zero_bytes;
+  off_t ofs;
+  struct file *file;
+};
+
 #include "threads/thread.h"
 void supplemental_page_table_init(struct supplemental_page_table *spt);
 bool supplemental_page_table_copy(struct supplemental_page_table *dst,

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -1,52 +1,65 @@
 /* anon.c: Implementation of page for non-disk image (a.k.a. anonymous page). */
 
-#include "vm/vm.h"
 #include "devices/disk.h"
+#include "threads/vaddr.h"
+#include "vm/vm.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
-static bool anon_swap_in (struct page *page, void *kva);
-static bool anon_swap_out (struct page *page);
-static void anon_destroy (struct page *page);
+static bool anon_swap_in(struct page *page, void *kva);
+static bool anon_swap_out(struct page *page);
+static void anon_destroy(struct page *page);
 
 /* DO NOT MODIFY this struct */
 static const struct page_operations anon_ops = {
-	.swap_in = anon_swap_in,
-	.swap_out = anon_swap_out,
-	.destroy = anon_destroy,
-	.type = VM_ANON,
+    .swap_in = anon_swap_in,
+    .swap_out = anon_swap_out,
+    .destroy = anon_destroy,
+    .type = VM_ANON,
 };
 
+/* 디스크에서 사용 가능한 swap slot과 사용 불가능한 swap slot을
+  관리하는 자료구조
+  bitmap 구조체 사용
+    - bit를 저장하는 연속된 메모리 공간 위의 배열 객체
+    - 각각의 비트가 swap_slot과 매칭, 1인 경우 swap out되어
+    디스크의 swap 공간에 임시 저장되었다는 뜻 */
+struct bitmap *swap_table;
+
+/* PGSZIE == 1<<12byte (4kb) / DISK_SECTOR_SIZE == 512byte
+  SECTOR_PER_PAGE == 8 */
+const size_t SECTOR_PER_PAGE = PGSIZE / DISK_SECTOR_SIZE;
+
 /* Initialize the data for anonymous pages */
-void
-vm_anon_init (void) {
-	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+void vm_anon_init(void) {
+  /* TODO: Set up the swap_disk. */
+  swap_disk = disk_get(1, 1);
+  size_t swap_size = disk_size(swap_disk) / SECTOR_PER_PAGE;
+  swap_table = bitmap_create(swap_size);
 }
 
 /* Initialize the file mapping */
-bool
-anon_initializer (struct page *page, enum vm_type type, void *kva) {
-	/* Set up the handler */
-	page->operations = &anon_ops;
+bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
+  /* Set up the handler */
+  page->operations = &anon_ops;
 
-	struct anon_page *anon_page = &page->anon;
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Swap in the page by read contents from the swap disk. */
 static bool
-anon_swap_in (struct page *page, void *kva) {
-	struct anon_page *anon_page = &page->anon;
+anon_swap_in(struct page *page, void *kva) {
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
 static bool
-anon_swap_out (struct page *page) {
-	struct anon_page *anon_page = &page->anon;
+anon_swap_out(struct page *page) {
+  struct anon_page *anon_page = &page->anon;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void
-anon_destroy (struct page *page) {
-	struct anon_page *anon_page = &page->anon;
+anon_destroy(struct page *page) {
+  struct anon_page *anon_page = &page->anon;
 }

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -40,10 +40,20 @@ void vm_anon_init(void) {
 
 /* Initialize the file mapping */
 bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
+  /* page struct 안의 union영역은 현재 uninit page
+    ANON page 0초기화 -> union영역 0초기화됨*/
+  struct uninit_page *uninit = &page->uninit;
+  memset(uninit, 0, sizeof(struct uninit_page));
+
   /* Set up the handler */
+  /* 해당 페이지는 이제 ANON*/
   page->operations = &anon_ops;
 
+  /* 해당 페이지는 아직 물리 메모리 위에 있음 -> swap_index값 -1로 설정*/
   struct anon_page *anon_page = &page->anon;
+  anon_page->swap_index = -1;
+
+  return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */


### PR DESCRIPTION
(procss.c)
load_segment(), lazy_load_segment(), setup_stack() 구현 및 수정

(vm.c)
supplemental_page_table_init()의 hash_init 첫 번째 인자 수정 (spt > &spt->spt_hash)
supplemental_page_table_copy() 구현
+
hash_action_destroy() 헬퍼함수
free_frame() 헬퍼함수 (process.c의 lazy_load_segment에서 사용)


![화면 캡처 2025-10-11 194452](https://github.com/user-attachments/assets/afc2590e-d50c-4c81-a856-65f49a0a492d)

위 6항목 제외하고 1-63 pass
위 항목은 모두 exit(-1)

anon.c 하기 전에 여기까지 구현해서 pass 띄워놓고 시작하길래 먼저 구현하고 PR합니다.

