### PR TITLE
fix: mmap 상속 방지 및 경계 검증 강화

### DIFF
--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -260,8 +260,6 @@ void do_munmap(void *addr) {
     struct page *page = spt_find_page(&curr->spt, page_addr);
 
     if (page != NULL) {
-      // destroy 호출 (file_backed_destroy가 dirty 체크 & write back 수행)
-      destroy(page);
       // SPT에서 제거
       spt_remove_page(&curr->spt, page);
     }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -379,7 +379,7 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst, struct su
       // 새로운 파일 로더(new_file_loader)를 할당하고 기존의 파일 로더 정보를 복사
       struct file_loader *new_file_loader = malloc(sizeof(struct file_loader));
       memcpy(new_file_loader, uninit_page->aux, sizeof(struct file_loader));
-      new_file_loader->file = file_duplicate(file_loader->file);  // 파일을 복제하여 새로운 파일 포인터를 생성
+      new_file_loader->file = file_reopen(file_loader->file);  // 파일을 복제하여 새로운 파일 포인터를 생성
 
       // 초기화할 페이지에 신규 파일 로더를 이용하여 초기화할 페이지 할당
       vm_alloc_page_with_initializer(uninit_page->type, src_page->va, src_page->writable, uninit_page->init, new_file_loader);


### PR DESCRIPTION
- fork 시 mmap 페이지(VM_FILE) 상속 방지
- mmap 커널 영역 침범 및 오버플로우 검증 추가 (최대 256MB)

수정 테스트: mmap-inherit, mmap-kernel